### PR TITLE
Error Handler: Introduce AXM68K bundle

### DIFF
--- a/modules/errorhandler/Debugger.Constants.asm
+++ b/modules/errorhandler/Debugger.Constants.asm
@@ -9,7 +9,12 @@
 
 ; General arguments format flags
 hex		equ		$80				; flag to display as hexadecimal number
+#ifdef BUNDLE-AXM68K
+## For AXM68K compatibility, we replace "dec" with "deci"
+deci	equ		$90				; flag to display as decimal number
+#else
 dec		equ		$90				; flag to display as decimal number
+#endif
 bin		equ		$A0				; flag to display as binary number
 sym		equ		$B0				; flag to display as symbol (treat as offset, decode into symbol +displacement, if present)
 symdisp	equ		$C0				; flag to display as symbol's displacement alone (DO NOT USE, unless complex formatting is required, see notes below)
@@ -21,7 +26,11 @@ str		equ		$D0				; flag to display as string (treat as offset, insert string fro
 ;		use "sym|split", so the displacement won't be displayed until symdisp is met
 ;	* The "symdisp" can only be used after the "sym|split" instance, which decodes offset, otherwise, it'll
 ;		display a garbage offset.
+#ifdef BUNDLE-AXM68K
 ;	* No other argument format flags (hex, dec, bin, str) are allowed between "sym|split" and "symdisp",
+#else
+;	* No other argument format flags (hex, deci, bin, str) are allowed between "sym|split" and "symdisp",
+#endif
 ;		otherwise, the "symdisp" results are undefined.
 ;	* When using "str" flag, the argument should point to string offset that will be inserted.
 ;		Arguments format flags CAN NOT be used in the string (as no arguments are meant to be here),
@@ -29,7 +38,11 @@ str		equ		$D0				; flag to display as string (treat as offset, insert string fro
 
 
 ; Additional flags ...
+#ifdef BUNDLE-AXM68K
+; ... for number formatters (hex, deci, bin)
+#else
 ; ... for number formatters (hex, dec, bin)
+#endif
 signed	equ		8				; treat number as signed (display + or - before the number depending on sign)
 
 ; ... for symbol formatter (sym)

--- a/modules/errorhandler/Debugger.Macros.ASM68K.asm
+++ b/modules/errorhandler/Debugger.Macros.ASM68K.asm
@@ -358,7 +358,7 @@ __FSTRING_GenerateArgumentsCode &
 __FSTRING_GenerateDecodedString &
 	macro string
 
-	__lpos:	= 1						; start position
+	__lpos:	= 1							; start position
 	__pos:	= instr(\string,'%<')		; token position
 
 	while (__pos)
@@ -387,7 +387,12 @@ __FSTRING_GenerateDecodedString &
 			endif
 
 			if (\__param < $80)
+#ifdef BUNDLE-AXM68K
+## For AXM68K compatibility, we replace "dec" with "deci"
+				inform	2,"Illegal operand format setting: ""\__param\"". Expected ""hex"", ""deci"", ""bin"", ""sym"", ""str"" or their derivatives."
+#else
 				inform	2,"Illegal operand format setting: ""\__param\"". Expected ""hex"", ""dec"", ""bin"", ""sym"", ""str"" or their derivatives."
+#endif
 			endif
 
 			if "\__type"=".b"

--- a/modules/errorhandler/Debugger.Macros.ASM68K.asm
+++ b/modules/errorhandler/Debugger.Macros.ASM68K.asm
@@ -301,16 +301,16 @@ __ErrorMessage &
 __FSTRING_GenerateArgumentsCode &
 	macro	string
 
-	__pos:	set 	instr(\string,'%<')		; token position
-	__stack:set		0						; size of actual stack
-	__sp:	set		0						; stack displacement
+	__pos:	= instr(\string,'%<')		; token position
+	__stack:= 0						; size of actual stack
+	__sp:	= 0						; stack displacement
 
 	; Parse string itself
 	while (__pos)
 
 		; Retrive expression in brackets following % char
-    	__endpos:	set		instr(__pos+1,\string,'>')
-    	__midpos:	set		instr(__pos+5,\string,' ')
+    	__endpos:	= instr(__pos+1,\string,'>')
+    	__midpos:	= instr(__pos+5,\string,' ')
     	if (__midpos<1)|(__midpos>__endpos)
 			__midpos: = __endpos
     	endif
@@ -343,7 +343,7 @@ __FSTRING_GenerateArgumentsCode &
 			endif
 		endif
 
-		__pos:	set		instr(__pos+1,\string,'%<')
+		__pos:	= instr(__pos+1,\string,'%<')
 	endw
 
 	; Generate stack code
@@ -358,8 +358,8 @@ __FSTRING_GenerateArgumentsCode &
 __FSTRING_GenerateDecodedString &
 	macro string
 
-	__lpos:	set		1						; start position
-	__pos:	set 	instr(\string,'%<')		; token position
+	__lpos:	= 1						; start position
+	__pos:	= instr(\string,'%<')		; token position
 
 	while (__pos)
 
@@ -368,8 +368,8 @@ __FSTRING_GenerateDecodedString &
 		dc.b	"\__substr"
 
 		; Retrive expression in brakets following % char
-    	__endpos:	set		instr(__pos+1,\string,'>')
-    	__midpos:	set		instr(__pos+5,\string,' ')
+    	__endpos:	= instr(__pos+1,\string,'>')
+    	__midpos:	= instr(__pos+5,\string,' ')
     	if (__midpos<1)|(__midpos>__endpos)
 			__midpos: = __endpos
     	endif
@@ -404,8 +404,8 @@ __FSTRING_GenerateDecodedString &
 			dc.b	\__substr
 		endif
 
-		__lpos:	set		__endpos+1
-		__pos:	set		instr(__pos+1,\string,'%<')
+		__lpos:	= __endpos+1
+		__pos:	= instr(__pos+1,\string,'%<')
 	endw
 
 	; Write part of string before the end

--- a/modules/errorhandler/Debugger.asm
+++ b/modules/errorhandler/Debugger.asm
@@ -35,8 +35,9 @@
 #ifdef BUNDLE-ASM68K
 #include Debugger.Macros.ASM68K.asm
 #endif
-##
-##
+#ifdef BUNDLE-AXM68K
+#include Debugger.Macros.ASM68K.asm
+#endif
 #ifdef BUNDLE-AS
 #include Debugger.Macros.AS.asm
 #endif

--- a/modules/errorhandler/Makefile
+++ b/modules/errorhandler/Makefile
@@ -10,9 +10,9 @@ SRC_FILES = $(wildcard $(SRC_DIR)/*.asm)
 CORE_SRC_FILES ?= $(wildcard ../errorhandler-core/*.asm) $(wildcard ../core/*.asm)
 
 
-.PHONY:	all asm68k asm68k-debug asm68k-extsym asm68k-linkable as as-extsym tests clean
+.PHONY:	all asm68k asm68k-debug asm68k-extsym asm68k-linkable axm68k axm68k-extsym as as-extsym tests clean
 
-all:	asm68k asm68k-debug asm68k-extsym asm68k-linkable as as-extsym
+all:	asm68k asm68k-debug asm68k-extsym asm68k-linkable axm68k axm68k-extsym as as-extsym
 
 asm68k:	$(BUILD_DIR)/asm68k/Debugger.asm $(BUILD_DIR)/asm68k/ErrorHandler.asm
 
@@ -21,6 +21,10 @@ asm68k-debug:	$(BUILD_DIR)/asm68k-debug/Debugger.asm $(BUILD_DIR)/asm68k-debug/E
 asm68k-extsym:	$(BUILD_DIR)/asm68k-extsym/Debugger.asm $(BUILD_DIR)/asm68k-extsym/ErrorHandler.asm
 
 asm68k-linkable:		$(BUILD_DIR)/asm68k-linkable/Debugger.asm $(BUILD_DIR)/asm68k-linkable/Debugger.obj
+
+axm68k:	$(BUILD_DIR)/axm68k/Debugger.asm $(BUILD_DIR)/axm68k/ErrorHandler.asm
+
+axm68k-extsym:	$(BUILD_DIR)/axm68k-extsym/Debugger.asm $(BUILD_DIR)/axm68k-extsym/ErrorHandler.asm
 
 as:	$(BUILD_DIR)/as/Debugger.asm $(BUILD_DIR)/as/ErrorHandler.asm
 
@@ -52,6 +56,16 @@ $(BUILD_DIR)/asm68k-linkable/Debugger.asm $(BUILD_DIR)/asm68k-linkable/Debugger.
 	mkdir -p $(BUILD_DIR)/asm68k-linkable
 	$(CBUNDLE) $(SRC_DIR)/Debugger.asm -def BUNDLE-ASM68K -def LINKABLE -def LINKABLE-WITH-DATA-SECTION -out $(BUILD_DIR)/asm68k-linkable/Debugger.asm
 	cp $(CORE_BUILD_DIR)/ErrorHandler.obj $(BUILD_DIR)/asm68k-linkable/Debugger.obj
+
+$(BUILD_DIR)/axm68k/Debugger.asm $(BUILD_DIR)/axm68k/ErrorHandler.asm &: 	$(SRC_FILES) $(CORE_BUILD_DIR)/ErrorHandler.Blob.asm $(CORE_BUILD_DIR)/ErrorHandler.Globals.asm | $(BUILD_DIR) $(CBUNDLE)
+	mkdir -p $(BUILD_DIR)/axm68k
+	$(CBUNDLE) $(SRC_DIR)/Debugger.asm -def BUNDLE-AXM68K -out $(BUILD_DIR)/axm68k/Debugger.asm
+	$(CBUNDLE) $(SRC_DIR)/ErrorHandler.asm -def BUNDLE-AXM68K -out $(BUILD_DIR)/axm68k/ErrorHandler.asm
+
+$(BUILD_DIR)/axm68k-extsym/Debugger.asm $(BUILD_DIR)/axm68k-extsym/ErrorHandler.asm &: $(SRC_FILES) $(CORE_BUILD_DIR)/ErrorHandler.ExtSymbols.Blob.asm $(CORE_BUILD_DIR)/ErrorHandler.ExtSymbols.Globals.asm | $(BUILD_DIR) $(CBUNDLE)
+	mkdir -p $(BUILD_DIR)/axm68k-extsym
+	$(CBUNDLE) $(SRC_DIR)/Debugger.asm -def BUNDLE-AXM68K -def EXTSYM -out $(BUILD_DIR)/axm68k-extsym/Debugger.asm
+	$(CBUNDLE) $(SRC_DIR)/ErrorHandler.asm -def BUNDLE-AXM68K -def EXTSYM -out $(BUILD_DIR)/axm68k-extsym/ErrorHandler.asm
 
 $(BUILD_DIR)/as/Debugger.asm $(BUILD_DIR)/as/ErrorHandler.asm &: $(SRC_FILES) $(CORE_BUILD_DIR)/ErrorHandler.Blob.asm $(CORE_BUILD_DIR)/ErrorHandler.Globals.asm | $(BUILD_DIR) $(CBUNDLE)
 	mkdir -p $(BUILD_DIR)/as

--- a/modules/errorhandler/Makefile.win
+++ b/modules/errorhandler/Makefile.win
@@ -10,9 +10,9 @@ SRC_FILES = $(wildcard $(SRC_DIR)\*.asm)
 CORE_SRC_FILES ?= $(wildcard ..\errorhandler-core\*.asm) $(wildcard ..\core\*.asm)
 
 
-.PHONY:	all asm68k asm68k-debug asm68k-extsym asm68k-linkable as as-extsym tests clean
+.PHONY:	all asm68k asm68k-debug asm68k-extsym asm68k-linkable axm68k axm68k-extsym as as-extsym tests clean
 
-all:	asm68k asm68k-debug asm68k-extsym asm68k-linkable as as-extsym
+all:	asm68k asm68k-debug asm68k-extsym asm68k-linkable axm68k axm68k-extsym as as-extsym
 
 asm68k:	$(BUILD_DIR)\asm68k\Debugger.asm $(BUILD_DIR)\asm68k\ErrorHandler.asm
 
@@ -21,6 +21,10 @@ asm68k-debug:	$(BUILD_DIR)\asm68k-debug\Debugger.asm $(BUILD_DIR)\asm68k-debug\E
 asm68k-extsym:	$(BUILD_DIR)\asm68k-extsym\Debugger.asm $(BUILD_DIR)\asm68k-extsym\ErrorHandler.asm
 
 asm68k-linkable:		$(BUILD_DIR)\asm68k-linkable\Debugger.asm $(BUILD_DIR)\asm68k-linkable\Debugger.obj
+
+axm68k:	$(BUILD_DIR)\axm68k\Debugger.asm $(BUILD_DIR)\axm68k\ErrorHandler.asm
+
+axm68k-extsym:	$(BUILD_DIR)\axm68k-extsym\Debugger.asm $(BUILD_DIR)\axm68k-extsym\ErrorHandler.asm
 
 as:	$(BUILD_DIR)\as\Debugger.asm $(BUILD_DIR)\as\ErrorHandler.asm
 
@@ -33,17 +37,17 @@ clean:
 	rd /s /q $(BUILD_DIR)
 
 
-$(BUILD_DIR)\asm68k\Debugger.asm $(BUILD_DIR)\asm68k\ErrorHandler.asm &:	$(SRC_FILES) $(CORE_BUILD_DIR)\ErrorHandler.Blob.asm $(CORE_BUILD_DIR)\ErrorHandler.Globals.asm | $(BUILD_DIR)
+$(BUILD_DIR)\asm68k\Debugger.asm $(BUILD_DIR)\asm68k\ErrorHandler.asm &:	$(SRC_FILES) $(CORE_BUILD_DIR)\ErrorHandler.Blob.asm $(CORE_BUILD_DIR)\ErrorHandler.Globals.asm | $(BUILD_DIR) $(CBUNDLE)
 	-md $(BUILD_DIR)\asm68k
 	$(CBUNDLE) $(SRC_DIR)\Debugger.asm -def BUNDLE-ASM68K -out $(BUILD_DIR)\asm68k\Debugger.asm
 	$(CBUNDLE) $(SRC_DIR)\ErrorHandler.asm -def BUNDLE-ASM68K -out $(BUILD_DIR)\asm68k\ErrorHandler.asm
 
-$(BUILD_DIR)\asm68k-debug\Debugger.asm $(BUILD_DIR)\asm68k-debug\ErrorHandler.asm &: $(SRC_FILES) $(CORE_BUILD_DIR)\ErrorHandler.Debug.Blob.asm $(CORE_BUILD_DIR)\ErrorHandler.Debug.Globals.asm | $(BUILD_DIR)
+$(BUILD_DIR)\asm68k-debug\Debugger.asm $(BUILD_DIR)\asm68k-debug\ErrorHandler.asm &: $(SRC_FILES) $(CORE_BUILD_DIR)\ErrorHandler.Debug.Blob.asm $(CORE_BUILD_DIR)\ErrorHandler.Debug.Globals.asm | $(BUILD_DIR) $(CBUNDLE)
 	-md $(BUILD_DIR)\asm68k-debug
 	$(CBUNDLE) $(SRC_DIR)\Debugger.asm -def BUNDLE-ASM68K -def DEBUG -out $(BUILD_DIR)\asm68k-debug\Debugger.asm
 	$(CBUNDLE) $(SRC_DIR)\ErrorHandler.asm -def BUNDLE-ASM68K -def DEBUG -out $(BUILD_DIR)\asm68k-debug\ErrorHandler.asm
 
-$(BUILD_DIR)\asm68k-extsym\Debugger.asm $(BUILD_DIR)\asm68k-extsym\ErrorHandler.asm &: $(SRC_FILES) $(CORE_BUILD_DIR)\ErrorHandler.ExtSymbols.Blob.asm $(CORE_BUILD_DIR)\ErrorHandler.ExtSymbols.Globals.asm | $(BUILD_DIR)
+$(BUILD_DIR)\asm68k-extsym\Debugger.asm $(BUILD_DIR)\asm68k-extsym\ErrorHandler.asm &: $(SRC_FILES) $(CORE_BUILD_DIR)\ErrorHandler.ExtSymbols.Blob.asm $(CORE_BUILD_DIR)\ErrorHandler.ExtSymbols.Globals.asm | $(BUILD_DIR) $(CBUNDLE)
 	-md $(BUILD_DIR)\asm68k-extsym
 	$(CBUNDLE) $(SRC_DIR)\Debugger.asm -def BUNDLE-ASM68K -def EXTSYM -out $(BUILD_DIR)\asm68k-extsym\Debugger.asm
 	$(CBUNDLE) $(SRC_DIR)\ErrorHandler.asm -def BUNDLE-ASM68K -def EXTSYM -out $(BUILD_DIR)\asm68k-extsym\ErrorHandler.asm
@@ -53,12 +57,22 @@ $(BUILD_DIR)\asm68k-linkable\Debugger.asm $(BUILD_DIR)\asm68k-linkable\Debugger.
 	$(CBUNDLE) $(SRC_DIR)/Debugger.asm -def BUNDLE-ASM68K -def LINKABLE -out $(BUILD_DIR)\asm68k-linkable\Debugger.asm
 	copy $(CORE_BUILD_DIR)\ErrorHandler.obj $(BUILD_DIR)\asm68k-linkable\Debugger.obj
 
-$(BUILD_DIR)\as\Debugger.asm $(BUILD_DIR)\as\ErrorHandler.asm &: $(SRC_FILES) $(CORE_BUILD_DIR)\ErrorHandler.Blob.asm $(CORE_BUILD_DIR)\ErrorHandler.Globals.asm | $(BUILD_DIR)
+$(BUILD_DIR)\axm68k\Debugger.asm $(BUILD_DIR)\axm68k\ErrorHandler.asm &: 	$(SRC_FILES) $(CORE_BUILD_DIR)\ErrorHandler.Blob.asm $(CORE_BUILD_DIR)\ErrorHandler.Globals.asm | $(BUILD_DIR) $(CBUNDLE)
+	-md $(BUILD_DIR)\axm68k
+	$(CBUNDLE) $(SRC_DIR)\Debugger.asm -def BUNDLE-AXM68K -out $(BUILD_DIR)\axm68k\Debugger.asm
+	$(CBUNDLE) $(SRC_DIR)\ErrorHandler.asm -def BUNDLE-AXM68K -out $(BUILD_DIR)\axm68k\ErrorHandler.asm
+
+$(BUILD_DIR)\axm68k-extsym\Debugger.asm $(BUILD_DIR)\axm68k-extsym\ErrorHandler.asm &: $(SRC_FILES) $(CORE_BUILD_DIR)\ErrorHandler.ExtSymbols.Blob.asm $(CORE_BUILD_DIR)\ErrorHandler.ExtSymbols.Globals.asm | $(BUILD_DIR) $(CBUNDLE)
+	-md $(BUILD_DIR)\axm68k-extsym
+	$(CBUNDLE) $(SRC_DIR)\Debugger.asm -def BUNDLE-AXM68K -def EXTSYM -out $(BUILD_DIR)\axm68k-extsym\Debugger.asm
+	$(CBUNDLE) $(SRC_DIR)\ErrorHandler.asm -def BUNDLE-AXM68K -def EXTSYM -out $(BUILD_DIR)\axm68k-extsym\ErrorHandler.asm
+
+$(BUILD_DIR)\as\Debugger.asm $(BUILD_DIR)\as\ErrorHandler.asm &: $(SRC_FILES) $(CORE_BUILD_DIR)\ErrorHandler.Blob.asm $(CORE_BUILD_DIR)\ErrorHandler.Globals.asm | $(BUILD_DIR) $(CBUNDLE)
 	-md $(BUILD_DIR)\as
 	$(CBUNDLE) $(SRC_DIR)\Debugger.asm -def BUNDLE-AS -out $(BUILD_DIR)\as\Debugger.asm
 	$(CBUNDLE) $(SRC_DIR)\ErrorHandler.asm -def BUNDLE-AS -out $(BUILD_DIR)\as\ErrorHandler.asm
 
-$(BUILD_DIR)\as-extsym\Debugger.asm $(BUILD_DIR)\as-extsym\ErrorHandler.asm &: $(SRC_FILES) $(CORE_BUILD_DIR)\ErrorHandler.ExtSymbols.Blob.asm $(CORE_BUILD_DIR)\ErrorHandler.ExtSymbols.Globals.asm | $(BUILD_DIR)
+$(BUILD_DIR)\as-extsym\Debugger.asm $(BUILD_DIR)\as-extsym\ErrorHandler.asm &: $(SRC_FILES) $(CORE_BUILD_DIR)\ErrorHandler.ExtSymbols.Blob.asm $(CORE_BUILD_DIR)\ErrorHandler.ExtSymbols.Globals.asm | $(BUILD_DIR) $(CBUNDLE)
 	-md $(BUILD_DIR)\as-extsym
 	$(CBUNDLE) $(SRC_DIR)\Debugger.asm -def BUNDLE-AS -def EXTSYM -out $(BUILD_DIR)\as-extsym\Debugger.asm
 	$(CBUNDLE) $(SRC_DIR)\ErrorHandler.asm -def BUNDLE-AS -def EXTSYM -out $(BUILD_DIR)\as-extsym\ErrorHandler.asm

--- a/modules/errorhandler/README.md
+++ b/modules/errorhandler/README.md
@@ -82,9 +82,10 @@ If you'd like to contribute new installation instructions or update the existing
 
 ## Supported assemblers
 
-Currently, the *Advanced Error Handler and Debugger 2.0* supports integration with the following assemblers:
+Currently, the *MD Debugger and Error Handler* supports integration with the following assemblers:
 
 * __ASM68K__ (`bundle-asm68k`)
+  * __AXM68K__, a hacked ASM68K usually bundled with macros for Z80 assembly support (`bundle-axm68k`)
 * __The AS Macroassembler__ v.1.42 Bld 55 and above (`bundle-as`)
 
 > **Warning**

--- a/modules/errorhandler/docs/Formatted_strings.md
+++ b/modules/errorhandler/docs/Formatted_strings.md
@@ -51,7 +51,8 @@ There are two types of tokes:
 
 - `format` (optional) - value format specifier; `hex` is used by default. The following formats are supported:
 	- `hex`, `hex|signed` - display as a hexadecimal number (unsigned or signed);
-	- `dec`, `hex|signed` - display as a decimal number (unsigned or signed);
+	- `dec`, `dec|signed` - display as a decimal number (unsigned or signed);
+		- **Note:** For AXM68K assembler, it's `deci` instead, because of a name conflict.
 	- `bin`, `bin|signed` - display as a binary number (unsigned or signed);
 	- `sym` - treat value as an offset, display as `symbol+displacement`;
 	- `str` - treat value as an offset, display null terminated C-string it points to.
@@ -113,4 +114,4 @@ SomeString:
 - `%<setx,X>` - set X-position of the next character on the line;
 	- __In AS version__, the syntax is `%<setx>%<X>` due to macros limitations.
 
-__In ASM68K version__, flags can be merged into a single token, for example: instead of `"%<endl>%<setx,2>%<pal0>"` you can just write `"%<endl,setx,2,pal0>"`.
+__In ASM68K version__, flags can be merged into a single token, for example: instead of `"%<endl>%<setx,2>%<pal0>"` you can just write `"%<endl,setx,2,pal0>"` (this also applied to AXM68K).

--- a/modules/errorhandler/docs/installation/Sonic_1_Hivebrain_2022.md
+++ b/modules/errorhandler/docs/installation/Sonic_1_Hivebrain_2022.md
@@ -8,7 +8,7 @@ The base disassembly used for this installation is available here: https://githu
 ## Step 1. Download and unpack the debugger
 
 1. Open the release page for the recent version of MD Debugger on GitHub: https://github.com/vladikcomper/md-modules/releases/tag/v.2.5
-2. Download the ASM68K version of MD Debugger (`errorhandler-asm68k.7z`);
+2. Download the ASM68K version of MD Debugger (`errorhandler-axm68k.7z`);
 3. Extract its files into disassembly's root directory.
 
 ## Steps 2-5


### PR DESCRIPTION
Fully support AXM68K assembler (a hacked ASM68K usually bundled with macros with Z80 assembly support) and the new Sonic 1 Hivebrain's disassembly.

- Add a dedicated `axm68k-bundle`;
  - Replaces `set` directive with `=` in macros to avoid name conflicts;
  - Renames `dec` to `deci` for the AXM68K version;
- Update documentation;

## TODO

- [x] Test Windows makefiles;
- [ ] Finish S1 Hivebrain 2022 installation guide;
- [ ] Fully test AXM68K version.
