### PR TITLE
Error Handler: Optimize `Console.Write`, slightly optimize symbol display

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ test:	all
 	$(MAKE) -C utils/cbundle test
 	$(MAKE) -C modules/mdshell tests
 	$(MAKE) -C modules/errorhandler tests
+	$(MAKE) -C modules/errorhandler-core tests
 
 clean:
 	rm -drf build/modules build/utils

--- a/Makefile.win
+++ b/Makefile.win
@@ -16,6 +16,7 @@ test:	all
 	make -C utils/cbundle -f Makefile.win test
 	make -C modules/mdshell -f Makefile.win tests
 	make -C modules/errorhandler -f Makefile.win tests
+	make -C modules/errorhandler-core -f Makefile.win tests
 
 clean:
 	rd /s /q build\modules build\utils

--- a/modules/core/Format_String.asm
+++ b/modules/core/Format_String.asm
@@ -87,10 +87,11 @@ FormatString_CodeHandlers:
 
 	; codes B0..BF : Display symbol
 	lea		FormatSym_Handlers(pc), a3			; $00
-	move.b	d3, d2								; $04
-	and.w	#3, d2								; $06	; d2 = 0, 1, 3 ... (ignore handlers for signed values)
-	add.w	d2, d2								; $0A	; multiply 4-bit code by 2 as instructions in the code handlers below are word-sized
-	jmp		@ArgumentFetchFlow(pc,d2)			; $0C	; jump to an appropriate instruction (note that even invalid codes won't crash)
+	moveq	#3, d2								; $04
+	and.b	d3, d2								; $06	; d2 = 0, 1, 3 ... (ignore handlers for signed values)
+	add.w	d2, d2								; $08	; multiply 4-bit code by 2 as instructions in the code handlers below are word-sized
+	jmp		@ArgumentFetchFlow(pc,d2)			; $0A	; jump to an appropriate instruction (note that even invalid codes won't crash)
+	nop											; $0E
 
 	; codes C0..CF : Display symbol's displacement (to be used after codes B0..BF, if extra formatting is due)
 	tst.w	d0									; $00	; check "GetSymbolByOffset" (see "FormatSym" code)

--- a/modules/errorhandler/Debugger.Macros.AS.asm
+++ b/modules/errorhandler/Debugger.Macros.AS.asm
@@ -138,17 +138,30 @@ Console	macro	argument1, argument2
 	switch lowstring("ATTRIBUTE")
 	case "write"
 		move.w	sr, -(sp)
+
 		__FSTRING_GenerateArgumentsCode argument1
-		movem.l	a0-a2/d7, -(sp)
-		lea		4*4(sp), a2
-		lea		.__data(pc), a1
-		jsr		__global__Console_Write_Formatted
-		movem.l	(sp)+, a0-a2/d7
-		if (.__sp>8)
-			lea		.__sp(sp), sp
-		elseif (.__sp>0)
-			addq.w	#.__sp, sp
+
+		; If we have any arguments in string, use formatted string function ...
+		if (.__sp>0)
+			movem.l	a0-a2/d7, -(sp)
+			lea		4*4(sp), a2
+			lea		.__data(pc), a1
+			jsr		__global__Console_Write_Formatted
+			movem.l	(sp)+, a0-a2/d7
+			if (.__sp>8)
+				lea		.__sp(sp), sp
+			elseif (.__sp>0)
+				addq.w	#.__sp, sp
+			endif
+		
+		; ... Otherwise, use direct write as an optimization
+		else
+			move.l	a0, -(sp)
+			lea		.__data(pc), a0
+			jsr		__global__Console_Write
+			move.l	(sp)+, a0
 		endif
+
 		move.w	(sp)+, sr
 		bra.w	.__leave
 	.__data:
@@ -158,17 +171,29 @@ Console	macro	argument1, argument2
 
 	case "writeline"
 		move.w	sr, -(sp)
+
 		__FSTRING_GenerateArgumentsCode argument1
-		movem.l	a0-a2/d7, -(sp)
-		lea		4*4(sp), a2
-		lea		.__data(pc), a1
-		jsr		__global__Console_WriteLine_Formatted
-		movem.l	(sp)+, a0-a2/d7
-		if (.__sp>8)
-			lea		.__sp(sp), sp
-		elseif (.__sp>0)
-			addq.w	#.__sp, sp
+
+		; If we have any arguments in string, use formatted string function ...
+		if (.__sp>0)
+			movem.l	a0-a2/d7, -(sp)
+			lea		4*4(sp), a2
+			lea		.__data(pc), a1
+			jsr		__global__Console_WriteLine_Formatted
+			movem.l	(sp)+, a0-a2/d7
+			if (.__sp>8)
+				lea		.__sp(sp), sp
+			elseif (.__sp>0)
+				addq.w	#.__sp, sp
+			endif
+		; ... Otherwise, use direct write as an optimization
+		else
+			move.l	a0, -(sp)
+			lea		.__data(pc), a0
+			jsr		__global__Console_WriteLine
+			move.l	(sp)+, a0
 		endif
+
 		move.w	(sp)+, sr
 		bra.w	.__leave
 	.__data:

--- a/modules/errorhandler/Debugger.Macros.ASM68K.asm
+++ b/modules/errorhandler/Debugger.Macros.ASM68K.asm
@@ -85,19 +85,30 @@ Console &
 
 	if strcmp("\0","write")|strcmp("\0","writeline")|strcmp("\0","Write")|strcmp("\0","WriteLine")
 		move.w	sr, -(sp)
+
 		__FSTRING_GenerateArgumentsCode \1
-		movem.l	a0-a2/d7, -(sp)
+
+		; If we have any arguments in string, use formatted string function ...
 		if (__sp>0)
+			movem.l	a0-a2/d7, -(sp)
 			lea		4*4(sp), a2
+			lea		@str\@(pc), a1
+			jsr		__global__Console_\0\_Formatted
+			movem.l	(sp)+, a0-a2/d7
+			if (__sp>8)
+				lea		__sp(sp), sp
+			else
+				addq.w	#__sp, sp
+			endc
+
+		; ... Otherwise, use direct write as an optimization
+		else
+			move.l	a0, -(sp)
+			lea		@str\@(pc), a0
+			jsr		__global__Console_\0
+			move.l	(sp)+, a0
 		endc
-		lea		@str\@(pc), a1
-		jsr		__global__Console_\0\_Formatted
-		movem.l	(sp)+, a0-a2/d7
-		if (__sp>8)
-			lea		__sp(sp), sp
-		elseif (__sp>0)
-			addq.w	#__sp, sp
-		endc
+
 		move.w	(sp)+, sr
 		bra.w	@instr_end\@
 	@str\@:


### PR DESCRIPTION
This PR adds optimizations that affect MD Debugger/Error Handler and MD Shell:

1. `Console.Write` and `Console.WriteLine` have been optimized and now generate faster code if formatted string doesn't include any arguments (registers or memory locations to print).

   It works by using direct writes in `Console.Write/.WriteLine` if string has no arguments.

   Previously, `Console_Write[Line]_Formatted` was always used which called `FormatString` under the hood. While reliable, formatted string implementation is much slower than direct writes implemented by `Console_Write[Line]`.

2. Symbol display handler was optimized by mere 4 CPU cycles.
