### PR TITLE
Error Handler: Compact offsets and symbol displacements

### DIFF
--- a/modules/core/Formatter_Sym.asm
+++ b/modules/core/Formatter_Sym.asm
@@ -86,10 +86,10 @@ FormatSym_Displacement:
 	bcs.s	FormatSym_Return
 @buffer_ok:
 
-	swap	d1								; swap displacement longword
-	tst.w	d1								; test higher 16-bits of displacement
-	beq		FormatHex_Word_Swapped			; if bits are empty, display displacement as word
-	bra		FormatHex_LongWord_Swapped		; otherwise, display longword
+	swap	d1											; swap displacement longword
+	tst.w	d1											; test higher 16-bits of displacement
+	beq		FormatHex_Word_Trim_Swapped					; if bits are empty, display displacement as word
+	bra		FormatHex_LongWord_Trim_Swapped_NonZero		; otherwise, display longword
 
 ; ---------------------------------------------------------------
 ; INPUT:

--- a/modules/errorhandler-core/ErrorHandler.asm
+++ b/modules/errorhandler-core/ErrorHandler.asm
@@ -599,7 +599,7 @@ Str_Caller:
  	dc.b	_pal1, 'Caller: ', 0
 
 Str_OffsetLocation:
-	dc.b	_pal2, _hex|long, ' ', _pal0, _sym|long|split|forced, _pal2, _disp|weak, 0
+	dc.b	_pal2, _hex|byte, _hex|word, ' ', _pal0, _sym|long|split|forced, _pal2, _disp|weak, 0
 
 Str_USP:
 	dc.b	_setx, $10, _pal0, 'usp: ', _pal2, _hex|long, 0

--- a/modules/errorhandler-core/ErrorHandler.asm
+++ b/modules/errorhandler-core/ErrorHandler.asm
@@ -339,7 +339,9 @@ Error_DrawOffsetLocation2:	__global
 	move.l	d1, -(sp)
 	move.l	d1, -(sp)
 	lea		(sp), a2						; a2 = arguments buffer
-	lea		Str_OffsetLocation(pc), a1
+
+Error_DrawOffsetLocation__inj:	__global
+	lea		Str_OffsetLocation_24bit(pc), a1
 	jsr		Console_WriteLine_Formatted(pc)
 	addq.w	#8,sp							; free arguments buffer
 	rts
@@ -598,8 +600,11 @@ Str_Offset:
 Str_Caller:
  	dc.b	_pal1, 'Caller: ', 0
 
-Str_OffsetLocation:
+Str_OffsetLocation_24bit:	__global
 	dc.b	_pal2, _hex|byte, _hex|word, ' ', _pal0, _sym|long|split|forced, _pal2, _disp|weak, 0
+
+Str_OffsetLocation_32bit:	__global
+	dc.b	_pal2, _hex|long, ' ', _pal0, _sym|long|split|forced, _pal2, _disp|weak, 0
 
 Str_USP:
 	dc.b	_setx, $10, _pal0, 'usp: ', _pal2, _hex|long, 0

--- a/modules/errorhandler-core/Makefile
+++ b/modules/errorhandler-core/Makefile
@@ -55,18 +55,24 @@ $(BUILD_DIR)/ErrorHandler.ExtSymbols.Globals.asm:	$(BUILD_DIR)/ErrorHandler.ExtS
 
 # Linkable blobs in assembly format
 
-$(BUILD_DIR)/ErrorHandler.Blob.asm:	$(BUILD_DIR)/ErrorHandler.bin | $(BUILD_DIR)
-	$(BLOBTOASM) $^ $@
+$(BUILD_DIR)/ErrorHandler.Blob.asm:	$(BUILD_DIR)/ErrorHandler.bin $(BUILD_DIR)/ErrorHandler.SymbolTable.log | $(BUILD_DIR)
+	$(BLOBTOASM) $(BUILD_DIR)/ErrorHandler.bin $@ -m $(SRC_DIR)/inject-tables/ErrorHandler.Blob.txt -t $(BUILD_DIR)/ErrorHandler.SymbolTable.log
 
-$(BUILD_DIR)/ErrorHandler.Debug.Blob.asm:	$(BUILD_DIR)/ErrorHandler.Debug.bin | $(BUILD_DIR)
-	$(BLOBTOASM) $^ $@
+$(BUILD_DIR)/ErrorHandler.Debug.Blob.asm:	$(BUILD_DIR)/ErrorHandler.Debug.bin $(BUILD_DIR)/ErrorHandler.Debug.SymbolTable.log | $(BUILD_DIR)
+	$(BLOBTOASM) $(BUILD_DIR)/ErrorHandler.Debug.bin $@ -m $(SRC_DIR)/inject-tables/ErrorHandler.Blob.txt -t $(BUILD_DIR)/ErrorHandler.Debug.SymbolTable.log
 
-$(BUILD_DIR)/ErrorHandler.ExtSymbols.Blob.asm:	$(BUILD_DIR)/ErrorHandler.ExtSymbols.bin $(BUILD_DIR)/ErrorHandler.ExtSymbols.InjectTable.log | $(BUILD_DIR)
-	$(BLOBTOASM) $(BUILD_DIR)/ErrorHandler.ExtSymbols.bin $@ -m $(SRC_DIR)/inject-tables/ErrorHandler.ExtSymbols.Blob.txt -t $(BUILD_DIR)/ErrorHandler.ExtSymbols.InjectTable.log
+$(BUILD_DIR)/ErrorHandler.ExtSymbols.Blob.asm:	$(BUILD_DIR)/ErrorHandler.ExtSymbols.bin $(BUILD_DIR)/ErrorHandler.ExtSymbols.SymbolTable.log | $(BUILD_DIR)
+	$(BLOBTOASM) $(BUILD_DIR)/ErrorHandler.ExtSymbols.bin $@ -m $(SRC_DIR)/inject-tables/ErrorHandler.ExtSymbols.Blob.txt -t $(BUILD_DIR)/ErrorHandler.ExtSymbols.SymbolTable.log
 
 
-$(BUILD_DIR)/ErrorHandler.ExtSymbols.InjectTable.log:	$(BUILD_DIR)/ErrorHandler.ExtSymbols.sym | $(CONVSYM)
-	$(CONVSYM) $^ $@ -output asm -inopt "/processLocals-" -outopt "%s: %X" -filter '__inject_.+'
+$(BUILD_DIR)/ErrorHandler.SymbolTable.log:	$(BUILD_DIR)/ErrorHandler.sym | $(CONVSYM)
+	$(CONVSYM) $^ $@ -output asm -inopt "/processLocals-" -outopt "%s: %X"
+
+$(BUILD_DIR)/ErrorHandler.Debug.SymbolTable.log:	$(BUILD_DIR)/ErrorHandler.Debug.sym | $(CONVSYM)
+	$(CONVSYM) $^ $@ -output asm -inopt "/processLocals-" -outopt "%s: %X"
+
+$(BUILD_DIR)/ErrorHandler.ExtSymbols.SymbolTable.log:	$(BUILD_DIR)/ErrorHandler.ExtSymbols.sym | $(CONVSYM)
+	$(CONVSYM) $^ $@ -output asm -inopt "/processLocals-" -outopt "%s: %X"
 
 
 $(BUILD_DIR):

--- a/modules/errorhandler-core/Makefile.win
+++ b/modules/errorhandler-core/Makefile.win
@@ -55,18 +55,24 @@ $(BUILD_DIR)\ErrorHandler.ExtSymbols.Globals.asm:	$(BUILD_DIR)\ErrorHandler.ExtS
 
 # Linkable blobs in assembly format
 
-$(BUILD_DIR)\ErrorHandler.Blob.asm:	$(BUILD_DIR)\ErrorHandler.bin | $(BUILD_DIR)
-	$(BLOBTOASM) $^ $@
+$(BUILD_DIR)\ErrorHandler.Blob.asm:	$(BUILD_DIR)\ErrorHandler.bin $(BUILD_DIR)\ErrorHandler.SymbolTable.log | $(BUILD_DIR)
+	$(BLOBTOASM) $(BUILD_DIR)\ErrorHandler.bin $@ -m $(SRC_DIR)\inject-tables\ErrorHandler.Blob.txt -t $(BUILD_DIR)\ErrorHandler.SymbolTable.log
 
-$(BUILD_DIR)\ErrorHandler.Debug.Blob.asm:	$(BUILD_DIR)\ErrorHandler.Debug.bin | $(BUILD_DIR)
-	$(BLOBTOASM) $^ $@
+$(BUILD_DIR)\ErrorHandler.Debug.Blob.asm:	$(BUILD_DIR)\ErrorHandler.Debug.bin $(BUILD_DIR)\ErrorHandler.Debug.SymbolTable.log | $(BUILD_DIR)
+	$(BLOBTOASM) $(BUILD_DIR)\ErrorHandler.Debug.bin $@ -m $(SRC_DIR)\inject-tables\ErrorHandler.Blob.txt -t $(BUILD_DIR)\ErrorHandler.Debug.SymbolTable.log
 
-$(BUILD_DIR)\ErrorHandler.ExtSymbols.Blob.asm:	$(BUILD_DIR)\ErrorHandler.ExtSymbols.bin $(BUILD_DIR)\ErrorHandler.ExtSymbols.InjectTable.log | $(BUILD_DIR)
-	$(BLOBTOASM) $(BUILD_DIR)\ErrorHandler.ExtSymbols.bin $@ -m $(SRC_DIR)\inject-tables\ErrorHandler.ExtSymbols.Blob.txt -t $(BUILD_DIR)\ErrorHandler.ExtSymbols.InjectTable.log
+$(BUILD_DIR)\ErrorHandler.ExtSymbols.Blob.asm:	$(BUILD_DIR)\ErrorHandler.ExtSymbols.bin $(BUILD_DIR)\ErrorHandler.ExtSymbols.SymbolTable.log | $(BUILD_DIR)
+	$(BLOBTOASM) $(BUILD_DIR)\ErrorHandler.ExtSymbols.bin $@ -m $(SRC_DIR)\inject-tables\ErrorHandler.ExtSymbols.Blob.txt -t $(BUILD_DIR)\ErrorHandler.ExtSymbols.SymbolTable.log
 
 
-$(BUILD_DIR)\ErrorHandler.ExtSymbols.InjectTable.log:	$(BUILD_DIR)\ErrorHandler.ExtSymbols.sym | $(CONVSYM)
-	$(CONVSYM) $^ $@ -output asm -inopt "/processLocals-" -outopt "%s: %X" -filter '__inject_.+'
+$(BUILD_DIR)\ErrorHandler.SymbolTable.log:	$(BUILD_DIR)\ErrorHandler.sym | $(CONVSYM)
+	$(CONVSYM) $^ $@ -output asm -inopt "/processLocals-" -outopt "%s: %X"
+
+$(BUILD_DIR)\ErrorHandler.Debug.SymbolTable.log:	$(BUILD_DIR)\ErrorHandler.Debug.sym | $(CONVSYM)
+	$(CONVSYM) $^ $@ -output asm -inopt "/processLocals-" -outopt "%s: %X"
+
+$(BUILD_DIR)\ErrorHandler.ExtSymbols.SymbolTable.log:	$(BUILD_DIR)\ErrorHandler.ExtSymbols.sym | $(CONVSYM)
+	$(CONVSYM) $^ $@ -output asm -inopt "/processLocals-" -outopt "%s: %X"
 
 
 $(BUILD_DIR):

--- a/modules/errorhandler-core/inject-tables/ErrorHandler.Blob.txt
+++ b/modules/errorhandler-core/inject-tables/ErrorHandler.Blob.txt
@@ -1,3 +1,1 @@
-__inject_symboldata_ptr_1+2:long:inline: SymbolData_Ptr
-__inject_symboldata_ptr_2+2:long:inline: SymbolData_Ptr
 Error_DrawOffsetLocation__inj+2:word:inline: DEBUGGER__STR_OFFSET_SELECTOR-__global__Error_DrawOffsetLocation__inj-2

--- a/modules/errorhandler-core/tests/FormatString.asm
+++ b/modules/errorhandler-core/tests/FormatString.asm
@@ -289,17 +289,17 @@ addTest macro args,source_str,compare_str
 	; #25: Labels test #2
 	addTest { <.l short_data_chunk+1> }, &
 			<$B3,$00>, &
-			<'short_data_chunk+0001'>
+			<'short_data_chunk+1'>
 
 	; #26: Labels test #3
 	addTest { <.l long_data_chunk+$10001> }, &
 			<$B3,$00>, &
-			<'long_data_chunk+00010001'>
+			<'long_data_chunk+10001'>
 
 	; #27: Buffer limit + Lables test
 	addTest { <.l long_data_chunk+$10001> }, &
 			<'Overflow>>> ',$B3,$00>, &
-			<'Overflow>>> long_data_chunk+0001'>
+			<'Overflow>>> long_data_chunk+1000'>
 
 	; #28: Signed hex numbers test
 	addTest { <.w $1234>, <.l -$01234567>, <.w $FFFF> }, &
@@ -324,12 +324,12 @@ addTest macro args,source_str,compare_str
 	; #32: Advanced symbol output test #2
 	addTest { <.l $101> }, &
 			<$B3,$00>, &
-			<'Offset_100+0001'>
+			<'Offset_100+1'>
 
 	; #33: Advanced symbol output test #3
 	addTest { <.l $1FF> }, &
 			<$B3,$00>, &
-			<'Offset_100+00FF'>
+			<'Offset_100+FF'>
 
 	; #34: Advanced symbol output test #4 (non-existent symbol)
 	addTest { <.l 0> }, &
@@ -359,7 +359,7 @@ addTest macro args,source_str,compare_str
 	; #39: Advanced symbol output test #9 (far away symbol)
 	addTest { <.l $20080> }, &
 			<$B7,$00>, &
-			<'long_data_chunk+00010000'>
+			<'long_data_chunk+10000'>
 
 	; #40: Advanced symbol output test #10 (RAM addr)
 	addTest { <.l $FF0000> }, &
@@ -374,12 +374,12 @@ addTest macro args,source_str,compare_str
 	; #42: Advanced symbol output test #12 (RAM addr)
 	addTest { <.l $FFFF0001> }, &
 			<$B3,$00>, &
-			<'RAM_Offset_FF0000+0001'>
+			<'RAM_Offset_FF0000+1'>
 
 	; #43: Advanced symbol output test #13 (RAM addr)
 	addTest { <.l $FFFF0002> }, &
 			<$B7,$00>, &
-			<'RAM_Offset_FF0000+0002'>
+			<'RAM_Offset_FF0000+2'>
 
 	; #44: Advanced symbol output test #10 (RAM addr #2)
 	addTest { <.l $FF8000> }, &
@@ -394,7 +394,7 @@ addTest macro args,source_str,compare_str
 	; #46: Advanced symbol output test #12 (RAM addr #2)
 	addTest { <.w $8001> }, &
 			<$B1,$00>, &
-			<'RAM_Offset_FFFF8000+0001'>
+			<'RAM_Offset_FFFF8000+1'>
 
 	; #47: Advanced symbol output test #13 (RAM addr #3)
 	addTest { <.w $FF> }, &
@@ -404,17 +404,17 @@ addTest macro args,source_str,compare_str
 	; #48: Symbol and displacement test #1
 	addTest { <.l $1001> }, &
 			<$B3+8,$C0,$00>, &
-			<'ShouldOverflowBufferWithDis+0001'>
+			<'ShouldOverflowBufferWithDis+1'>
 
 	; #49: Symbol and displacement test #2
 	addTest { <.l $1001> }, &
-			<$B3+8,$C0,'this is no longer visible!',$00>, &
-			<'ShouldOverflowBufferWithDis+0001'>
+			<'>>>',$B3+8,$C0,'this is no longer visible!',$00>, &
+			<'>>>ShouldOverflowBufferWithDis+1'>
 
 	; #50: Symbol and displacement test #3
 	addTest { <.l $1001> }, &
-			<$B3+8,'(',$C0,')',$00>, &
-			<'ShouldOverflowBufferWithDis(+000'>
+			<'>>>',$B3+8,'(',$C0,')',$00>, &
+			<'>>>ShouldOverflowBufferWithDis(+'>
 
 	; #51: Symbol and displacement test #4
 	addTest { <.l $1000> }, &
@@ -423,13 +423,13 @@ addTest macro args,source_str,compare_str
 
 	; #52: Symbol and displacement test #5
 	addTest { <.l $1003> }, &
-			<$B3,$00>, &
-			<'ShouldOverflowBufferWithDisp+000'>
+			<'>>>>',$B3,$00>, &
+			<'>>>>ShouldOverflowBufferWithDisp'>
 
 	; #53: Symbol and displacement test #6
 	addTest { <.l $1005> }, &
 			<$B3,$00>, &
-			<'ShouldOverflowBufferWithDisp2+00'>
+			<'ShouldOverflowBufferWithDisp2+1'>
 
 	; #54: Symbol and displacement test #7
 	addTest { <.l $1007> }, &
@@ -445,6 +445,16 @@ addTest macro args,source_str,compare_str
 	addTest { <.l $100B> }, &
 			<$B3,$00>, &
 			<'ShouldOverflowBufferEvenWithoutD'>
+
+	; #57: Symbol and displacement test #10
+	addTest { <.l long_data_chunk+$10010> }, &
+			<$B3,$00>, &
+			<'long_data_chunk+10010'>
+
+	; #58: Symbol and displacement test #11
+	addTest { <.l long_data_chunk+$100010> }, &
+			<$B3,$00>, &
+			<'long_data_chunk+100010'>
 
 	dc.w	-1
 	 

--- a/modules/errorhandler/Debugger.Extensions.asm
+++ b/modules/errorhandler/Debugger.Extensions.asm
@@ -2,6 +2,11 @@
 ; Debugger customization
 ; ---------------------------------------------------------------
 
+; Use compact 24-bit offsets instead of 32-bit ones
+; This will display shorter offests next to the symbols in the exception screen header.
+; M68K bus is limited to 24 bits anyways, so not displaying unused bits saves screen space.
+DEBUGGER__USE_COMPACT_OFFSETS:			equ		1		; 0 = OFF, 1 = ON
+
 ; Enable debugger extensions
 ; Pressing A/B/C on the exception screen can open other debuggers
 ; Pressing Start or unmapped button returns to the exception

--- a/modules/errorhandler/ErrorHandler.asm
+++ b/modules/errorhandler/ErrorHandler.asm
@@ -36,6 +36,20 @@
 #endif
 ##
 
+; ---------------------------------------------------------------
+; Additional parameters
+; ---------------------------------------------------------------
+
+	if DEBUGGER__USE_COMPACT_OFFSETS
+		DEBUGGER__STR_OFFSET_SELECTOR:	equ	__global__Str_OffsetLocation_24bit
+	else
+		DEBUGGER__STR_OFFSET_SELECTOR:	equ	__global__Str_OffsetLocation_32bit
+#ifdef BUNDLE-ASM68K
+	endc
+#else
+	endif
+#endif
+
 #include ErrorHandler.Extensions.asm
 
 ; ---------------------------------------------------------------

--- a/utils/blobtoasm/blobtoasm.py
+++ b/utils/blobtoasm/blobtoasm.py
@@ -146,7 +146,7 @@ def tokenizeBlob(blob: bytes, symbolTable: Dict[str, int], injectionData: Dict[i
 	# Make data ranges ...
 	data_ranges: List[Tuple[int, int]] = []
 	start_offset = 0
-	for inject_offset, inject_data in injectionData.items():
+	for inject_offset, inject_data in sorted(injectionData.items()):
 		data_ranges.append((start_offset, inject_offset))
 		start_offset = inject_offset + inject_data.size
 	data_ranges.append((start_offset, len(blob)))


### PR DESCRIPTION
This PR implements compact offsets and symbol displacements in MD Debugger and Error Handler to save screen space and avoid line-breaks.

![image](https://github.com/vladikcomper/md-modules/assets/18137266/c553ce68-de3d-40e8-9cc6-9b23826db293)

- Offsets are 24-bit when displaying locations (e.g.: `00000200 EntryPoint`  -> `000200 EntryPoint` ;
- Displacements now use shorter format with leading zeroes trimmed: (e.g. `SomeRoutine+000E` -> `SomeRoutine+E`).

## TODO

- [ ] Test 24-bit offsets more thoroughly (esp. memory locations);
- [x] An option to revert to 32-bit offsets;
- [ ] Test an option to revert to 32-bit offsets;
- [ ] Test Windows Makefile.
