### PR TITLE
Error Hander: Support `KDebug.WriteLine` in Console programs

### DIFF
--- a/modules/core/Console.defs.asm
+++ b/modules/core/Console.defs.asm
@@ -16,7 +16,8 @@ _CONSOLE_DEFS:	equ	1
 
 			rsreset
 Console_RAM				equ		__rs
-Console.ScreenPosReq	rs.l	1				;		screen position request for VDP
+Console.ScreenPosReq	rs.l	1				;		current on-screen position request for VDP
+Console.ScreenRowReq:	rs.l	1				;		start of row position request for VDP
 Console.CharsPerLine	rs.w	1				; d2	number of characters per line
 Console.CharsRemaining	rs.w	1				; d3	remaining number of characters
 Console.BasePattern		rs.w	1				; d4	base pattern

--- a/modules/core/KDebug.asm
+++ b/modules/core/KDebug.asm
@@ -28,21 +28,14 @@ KDebug_Write_Formatted: __global
 
 @buffer_size = $10
 
-	move.l	usp, a0
-	cmp.b	#_ConsoleMagic, Console.Magic(a0)	; are we running console?
-	beq.s	@quit						; if yes, disable KDebug output, because it breaks VDP address
-
 	move.l	a4, -(sp)
 	lea		@FlushBuffer(pc), a4		; flushing function
 	lea		-@buffer_size(sp), sp		; allocate string buffer
 	lea		(sp), a0					; a0 = string buffer
 	moveq	#@buffer_size-2, d7			; d7 = number of characters before flush -1
-
 	jsr		FormatString(pc)
 	lea		@buffer_size(sp), sp		; free string buffer
-	
 	move.l	(sp)+, a4
-@quit:
 	rts
 
 ; ---------------------------------------------------------------
@@ -101,14 +94,7 @@ KDebug_Write_Formatted: __global
 ; -----------------------------------------------------------------------------
 
 KDebug_FlushLine:	__global
-	move.l	a0, -(sp)
-	move.l	usp, a0
-	cmp.b	#_ConsoleMagic, Console.Magic(a0)	; are we running console?
-	beq.s	@quit						; if yes, disable KDebug output, because it breaks VDP address
-
 	move.w	#$9E00, VDP_Ctrl			; send null-terminator
-@quit:
-	move.l	(sp)+, a0
 	rts
 
 
@@ -133,10 +119,6 @@ KDebug_WriteLine:	__global
 KDebug_Write:	__global
 	move.w	d7, -(sp)
 	move.l	a5, -(sp)
-
-	move.l	usp, a5
-	cmp.b	#_ConsoleMagic, Console.Magic(a5)	; are we running console?
-	beq.s	@write_buffer_done					; if yes, disable KDebug output, because it breaks VDP address
 
 	lea		VDP_Ctrl, a5
 	move.w	#$9E00, d7

--- a/modules/core/KDebug.defs.asm
+++ b/modules/core/KDebug.defs.asm
@@ -27,7 +27,7 @@ KDebug &
 			lea		4*4(sp), a2
 		endc
 		lea		@str\@(pc), a1
-		jsr		KDebug_\0\_Formatted
+		jsr		KDebug_\0\_Formatted(pc)
 		movem.l	(sp)+, a0-a2/d7
 		if (__sp>8)
 			lea		__sp(sp), sp
@@ -43,7 +43,7 @@ KDebug &
 
 	elseif strcmp("\0","breakline")|strcmp("\0","BreakLine")
 		move.w	sr, -(sp)
-		jsr		KDebug_FlushLine
+		jsr		KDebug_FlushLine(pc)
 		move.w	(sp)+, sr
 
 	elseif strcmp("\0","starttimer")|strcmp("\0","StartTimer")

--- a/modules/core/KDebug.defs.asm
+++ b/modules/core/KDebug.defs.asm
@@ -21,19 +21,30 @@ KDebug &
 	if def(__DEBUG__)	; KDebug interface is only available in DEBUG builds
 	if strcmp("\0","write")|strcmp("\0","writeline")|strcmp("\0","Write")|strcmp("\0","WriteLine")
 		move.w	sr, -(sp)
+
 		__FSTRING_GenerateArgumentsCode \1
-		movem.l	a0-a2/d7, -(sp)
+
+		; If we have any arguments in string, use formatted string function ...
 		if (__sp>0)
+			movem.l	a0-a2/d7, -(sp)
 			lea		4*4(sp), a2
+			lea		@str\@(pc), a1
+			jsr		__global__KDebug_\0\_Formatted(pc)
+			movem.l	(sp)+, a0-a2/d7
+			if (__sp>8)
+				lea		__sp(sp), sp
+			elseif (__sp>0)
+				addq.w	#__sp, sp
+			endc
+
+		; ... Otherwise, use direct write as an optimization
+		else
+			move.l	a0, -(sp)
+			lea		@str\@(pc), a0
+			jsr		__global__KDebug_\0(pc)
+			move.l	(sp)+, a0
 		endc
-		lea		@str\@(pc), a1
-		jsr		KDebug_\0\_Formatted(pc)
-		movem.l	(sp)+, a0-a2/d7
-		if (__sp>8)
-			lea		__sp(sp), sp
-		elseif (__sp>0)
-			addq.w	#__sp, sp
-		endc
+
 		move.w	(sp)+, sr
 		bra.w	@instr_end\@
 	@str\@:

--- a/modules/errorhandler/Debugger.Macros.AS.asm
+++ b/modules/errorhandler/Debugger.Macros.AS.asm
@@ -255,10 +255,14 @@ Console	macro	argument1, argument2
 	endcase
 	endm
 
-#ifndef MD-SHELL
 ; ---------------------------------------------------------------
+; KDebug integration interface
+; ---------------------------------------------------------------
+
 KDebug	macro	argument1
+#ifndef MD-SHELL
 	ifdef __DEBUG__	; KDebug interface is only available in DEBUG builds
+#endif
 	switch lowstring("ATTRIBUTE")
 	case "write"
 		move.w	sr, -(sp)
@@ -349,10 +353,11 @@ KDebug	macro	argument1
 		!error	"ATTRIBUTE isn't a member of KDebug"
 
 	endcase
+#ifndef MD-SHELL
 	endif
+#endif
 	endm
 
-#endif
 ; ---------------------------------------------------------------
 __ErrorMessage  macro string, opts
 		__FSTRING_GenerateArgumentsCode string

--- a/modules/errorhandler/Debugger.Macros.ASM68K.asm
+++ b/modules/errorhandler/Debugger.Macros.ASM68K.asm
@@ -170,12 +170,16 @@ Console &
 	endc
 	endm
 
-#ifndef MD-SHELL
 ; ---------------------------------------------------------------
+; KDebug integration interface
+; ---------------------------------------------------------------
+
 KDebug &
 	macro
 
+#ifndef MD-SHELL
 	if def(__DEBUG__)	; KDebug interface is only available in DEBUG builds
+#endif
 	if strcmp("\0","write")|strcmp("\0","writeline")|strcmp("\0","Write")|strcmp("\0","WriteLine")
 		move.w	sr, -(sp)
 
@@ -233,10 +237,11 @@ KDebug &
 		inform	2,"""\0"" isn't a member of ""KDebug"""
 
 	endc
+#ifndef MD-SHELL
 	endc
+#endif
 	endm
 
-#endif
 ; ---------------------------------------------------------------
 __ErrorMessage &
 	macro	string, opts

--- a/modules/errorhandler/README.md
+++ b/modules/errorhandler/README.md
@@ -42,7 +42,7 @@ Currently, it targets **The AS Macroassembler** and **ASM68K** assemblers. It ha
   - Assertions, widely adopted by many high-level languages, are provided by the debugger out-of-the box;
   - Use `assert` pseudo-instruction that is only compiled in DEBUG builds. This means zero run-time cost for your final (RELEASE) builds to implement self-testing code.
 
-- __KDebug integration for logging, breakpoints and cycle-counting (experimental).__
+- __KDebug integration for logging, breakpoints and cycle-counting.__
   - Display formatted strings at any point straight in your emulator's debug console!
   - Use a similar "high-level" macro interface as in console programs (`KDebug.WriteLine` instead of `Console.WriteLine`), but without interrupting your programs;
   - Currently, the only emulators to support KDebug are Gens KMod and Blastem-nightly;

--- a/modules/errorhandler/docs/how-to/Troubleshoot.md
+++ b/modules/errorhandler/docs/how-to/Troubleshoot.md
@@ -64,15 +64,12 @@ MyFunction:
 	endc					; endif in AS
 ```
 
-## Problem: Using `KDebug` or `Console.Write` alongside VRAM writes has side effects
+## Problem: Using `KDebug` or `Console` alongside VRAM writes has side effects
 
-Be extremely careful when using `KDebug` or `Console.Write`/`.WriteLine`/`.BreakLine` to debug code that does VRAM/CRAM/VSRAM access. All these macros access VDP, so it resets the last accessed VRAM/CRAM/VSRAM address. Moreover, setting a different VRAM/CRAM/VSRAM address in-between `Console.Write` calls will disrupt Console output, because `Console` expects last VRAM address to point to the next on-screen tile to draw on.
+Be extremely careful when using `KDebug` or `Console.Write`/`.WriteLine`/`.BreakLine` to debug code that does VRAM/CRAM/VSRAM access. All these macros access VDP, so it resets the last accessed VRAM/CRAM/VSRAM address. Moreover, `Console.Write` calls set last write address to on-screen output so your code may output data to the screen instead of the intended location.
 
 This is a hardware limitation unfortunately, there isn't a universal workaround for this.
 
 To make debugging VDP writes as pain-free as possible, follow this advice:
-1. Use `Console.BreakLine` before `Console.Write`, `Console.WriteLine` to reset VDP access address; `Console.Write "%<endl>You new line"` also works;
-2. Avoid writing to VDP in-between `Console.Write` calls; if you absolutely have to, manually set the write address each time and use the advice above with `Console.BreakLine`;
-3. Prefer `KDebug.WriteLine` if possible as it only resets the last accessed VDP address, but doesn't do any VDP writes.
-
-
+- Make sure you don't call `KDebug` or `Console` macros in-between VDP data port writes.
+- If you absolutely have to, manually set VDP write address after each macro call.

--- a/modules/errorhandler/docs/how-to/Use_KDebug_integration.md
+++ b/modules/errorhandler/docs/how-to/Use_KDebug_integration.md
@@ -60,7 +60,7 @@ Viewing messages on Linux is easy and straightforward: just launch the emulator 
 
 ## Setting up Gens KMod (not recommended)
 
-> **Warning**
+> [!WARNING]
 > 
 > Kens KMod is a heavily outdated and inaccurate emulator. **Using it is not recommended.**
 

--- a/modules/errorhandler/tests/.Makefile
+++ b/modules/errorhandler/tests/.Makefile
@@ -22,11 +22,11 @@ clean:
 
 
 console-run:	| $(TEST_BUILD_DIR) $(MDSHELL_HEADLESS) $(CONVSYM)
-	$(ASM68K) /k /m /o c+ /o ws+ /o op+ /o os+ /o ow+ /o oz+ /o oaq+ /o osq+ /o omq+ /p /o ae- console-run.asm, $(TEST_BUILD_DIR)/console-run.gen, $(TEST_BUILD_DIR)/console-run.sym, $(TEST_BUILD_DIR)/console-run.lst
+	$(ASM68K) /k /m /o c+ /o ws+ /o op+ /o os+ /o ow+ /o oz+ /o oaq+ /o osq+ /o omq+ /p /o ae- /e __DEBUG__ console-run.asm, $(TEST_BUILD_DIR)/console-run.gen, $(TEST_BUILD_DIR)/console-run.sym, $(TEST_BUILD_DIR)/console-run.lst
 	$(CONVSYM) $(TEST_BUILD_DIR)/console-run.sym $(TEST_BUILD_DIR)/console-run.gen -input asm68k_sym -output deb2 -a -ref 200
 
 raise-error:	| $(TEST_BUILD_DIR) $(MDSHELL_HEADLESS) $(CONVSYM)
-	$(ASM68K) /k /m /o c+ /o ws+ /o op+ /o os+ /o ow+ /o oz+ /o oaq+ /o osq+ /o omq+ /p /o ae- raise-error.asm, $(TEST_BUILD_DIR)/raise-error.gen, $(TEST_BUILD_DIR)/raise-error.sym, $(TEST_BUILD_DIR)/raise-error.lst
+	$(ASM68K) /k /m /o c+ /o ws+ /o op+ /o os+ /o ow+ /o oz+ /o oaq+ /o osq+ /o omq+ /p /o ae- /e __DEBUG__ raise-error.asm, $(TEST_BUILD_DIR)/raise-error.gen, $(TEST_BUILD_DIR)/raise-error.sym, $(TEST_BUILD_DIR)/raise-error.lst
 	$(CONVSYM) $(TEST_BUILD_DIR)/raise-error.sym $(TEST_BUILD_DIR)/raise-error.gen -input asm68k_sym -output deb2 -a -ref 200
 
 console-utils:	| $(TEST_BUILD_DIR) $(MDSHELL_HEADLESS) $(CONVSYM) $(CBUNDLE)

--- a/modules/errorhandler/tests/.Makefile.win
+++ b/modules/errorhandler/tests/.Makefile.win
@@ -23,11 +23,11 @@ clean:
 
 
 console-run:	| $(TEST_BUILD_DIR) $(MDSHELL_HEADLESS) $(CONVSYM)
-	$(ASM68K) /k /m /o c+ /o ws+ /o op+ /o os+ /o ow+ /o oz+ /o oaq+ /o osq+ /o omq+ /p /o ae- console-run.asm, $(TEST_BUILD_DIR)\console-run.gen, $(TEST_BUILD_DIR)\console-run.sym, $(TEST_BUILD_DIR)\console-run.lst
+	$(ASM68K) /k /m /o c+ /o ws+ /o op+ /o os+ /o ow+ /o oz+ /o oaq+ /o osq+ /o omq+ /p /o ae- /e __DEBUG__ console-run.asm, $(TEST_BUILD_DIR)\console-run.gen, $(TEST_BUILD_DIR)\console-run.sym, $(TEST_BUILD_DIR)\console-run.lst
 	$(CONVSYM) $(TEST_BUILD_DIR)\console-run.sym $(TEST_BUILD_DIR)\console-run.gen -input asm68k_sym -output deb2 -a -ref 200
 
 raise-error:	| $(TEST_BUILD_DIR $(MDSHELL_HEADLESS) $(CONVSYM)
-	$(ASM68K) /k /m /o c+ /o ws+ /o op+ /o os+ /o ow+ /o oz+ /o oaq+ /o osq+ /o omq+ /p /o ae- raise-error.asm, $(TEST_BUILD_DIR)\raise-error.gen, $(TEST_BUILD_DIR)\raise-error.sym, $(TEST_BUILD_DIR)\raise-error.lst
+	$(ASM68K) /k /m /o c+ /o ws+ /o op+ /o os+ /o ow+ /o oz+ /o oaq+ /o osq+ /o omq+ /p /o ae- /e __DEBUG__ raise-error.asm, $(TEST_BUILD_DIR)\raise-error.gen, $(TEST_BUILD_DIR)\raise-error.sym, $(TEST_BUILD_DIR)\raise-error.lst
 	$(CONVSYM) $(TEST_BUILD_DIR)\raise-error.sym $(TEST_BUILD_DIR)\raise-error.gen -input asm68k_sym -output deb2 -a -ref 200
 
 console-utils:	| $(TEST_BUILD_DIR) $(MDSHELL_HEADLESS) $(CONVSYM) $(CBUNDLE)

--- a/modules/errorhandler/tests/console-run.asm
+++ b/modules/errorhandler/tests/console-run.asm
@@ -9,7 +9,7 @@
 
 	include	"..\..\..\build\modules\mdshell\headless\MDShell.asm"
 
-	include	"..\..\..\build\modules\errorhandler\asm68k\Debugger.asm"
+	include	"..\..\..\build\modules\errorhandler\asm68k-debug\Debugger.asm"
 
 ; --------------------------------------------------------------
 
@@ -47,4 +47,4 @@ GlobalData:
 
 ; --------------------------------------------------------------
 
-	include	"..\..\..\build\modules\errorhandler\asm68k\ErrorHandler.asm"
+	include	"..\..\..\build\modules\errorhandler\asm68k-debug\ErrorHandler.asm"

--- a/modules/errorhandler/tests/console-utils.asm
+++ b/modules/errorhandler/tests/console-utils.asm
@@ -29,9 +29,13 @@ Main:
 
 ; --------------------------------------------------------------
 TestProgram:
+	KDebug.WriteLine "Entering test program..."
+
 	Console.SetXY #1, #1
 	Console.Write "%<pal1>Refreshing in ~1 second..."
+	KDebug.WriteLine "About to call Console.Sleep..."
 	Console.Sleep #60
+	KDebug.WriteLine "Console.Sleep finished"
 	Console.Clear
 
 	Console.WriteLine "Refreshed!"
@@ -49,37 +53,20 @@ TestProgram:
 	jsr		CheckRegisterIntergity
 
 	Console.Write "Paused. Press A/B/C/Start to continue..."
+	KDebug.WriteLine "Prepare to call Console.Pause..."
 	Console.Pause
+	KDebug.WriteLine "Console.Pause called"
 	Console.WriteLine "WELL PRESSED!"
+	KDebug.WriteLine "Printed success message to the console"
 
 	jsr		CheckRegisterIntergity
 
-	KDebug.WriteLine "You shouldn't see this."
-	KDebug.Write "You still shouldn't see "
-	KDebug.Write "this!%<endl>"
-
-	; WARNING! This temporarily disables console!
-	pea		0.w							; allocate 4 bytes on the stack
-	move.l	a3, -(sp)
-	move.l	usp, a3
-	move.l	a3, 4(sp)					; remember USP
-	suba.w	a3, a3
-	move.l	a3, usp
-	move.l	(sp)+, a3
-
-	KDebug.WriteLine "You should see this now!"
-	KDebug.Write "You still should see "
-	KDebug.Write "this!%<endl>"
+	KDebug.WriteLine "Testing KDebug writes exclusively..."
+	KDebug.Write "You should see "
+	KDebug.Write "this line once endl token is encountered!%<endl>"
 	KDebug.Write "This line is extremely long and certainly flushes the buffer several times!"
 	KDebug.BreakLine
 
-	; WARNING! This re-enables console
-	move.l	a3, -(sp)
-	move.l	4(sp), a3
-	move.l	a3, usp
-	move.l	(sp)+, a3
-	addq.w	#4, sp						; free 4 bytes we previously allocated
-
 	KDebug.StartTimer
 	nop
 	nop
@@ -100,6 +87,7 @@ TestProgram:
 	nop
 	KDebug.EndTimer
 
+	KDebug.WriteLine "You should see debugger now. Type 'c' and press Enter to continue..."
 	KDebug.BreakPoint
 
 	Console.BreakLine

--- a/modules/errorhandler/tests/raise-error.asm
+++ b/modules/errorhandler/tests/raise-error.asm
@@ -9,7 +9,7 @@
 
 	include	"..\..\..\build\modules\mdshell\headless\MDShell.asm"
 
-	include	"..\..\..\build\modules\errorhandler\asm68k\Debugger.asm"
+	include	"..\..\..\build\modules\errorhandler\asm68k-debug\Debugger.asm"
 
 ; --------------------------------------------------------------
 
@@ -30,4 +30,4 @@ MyErrorHandler:
 
 ; --------------------------------------------------------------
 
-	include	"..\..\..\build\modules\errorhandler\asm68k\ErrorHandler.asm"
+	include	"..\..\..\build\modules\errorhandler\asm68k-debug\ErrorHandler.asm"


### PR DESCRIPTION
This PR makes `Console` write subroutines always track and update VDP access address even between buffer flushes. This makes it possible to utilize `KDebug.Write/WriteLine` in Console programs, which previously broke Console writes because using VDP registers in KDebug resets VDP access.

## Changeset

**Modules core**

- Fix broken absolute jumps in internal `KDebug` macros;
- Use direct writes in internal `KDebug.Write`/`.WriteLine` if string has no bound arguments (the same optimization as in external MD Debugger macros);

**MD Debugger and Error Handler**

- Reload last VDP access address in-between `Console` writes to be able to use `KDebug` in Console programs;
- Don't suppress `KDebug` in Console programs anymore;
- Updated tests, use debug bundle for ASM68K tests;
- Updated documentation, `KDebug` is no longer experimental.

**MD Shell**

- Include `KDebug` macros from MD Debugger in bundles because it no longer conflicts with Console.
