### PR TITLE
Apply some bugfixes and optimizations I found

### DIFF
--- a/modules/core/Console.asm
+++ b/modules/core/Console.asm
@@ -43,7 +43,6 @@ Console_Init:	__global
 	addq.w	#2, a1					; skip end marker
 
 	; Load palette
-	lea		Console_FillTile(pc), a0
 	cram	$00, (a5)				; VDP => Setup CRAM write at offset $00
 	moveq	#0, d0					; d0 = black color
 	moveq	#4-1, d3				; d3 = number of palette lines - 1
@@ -56,7 +55,7 @@ Console_Init:	__global
 		bpl.s	@0					; if color, branch
 
 		moveq	#0, d1
-		jsr		$10(a0,d2)			; fill the rest of cram by a clever jump (WARNING! Precision required!)
+		jsr		Console_FillTile+$10(pc,d2)			; fill the rest of cram by a clever jump (WARNING! Precision required!)
 		dbf		d3, @fill_palette_line
 	; fallthrough
 
@@ -234,7 +233,7 @@ Console_SetBasePattern: __global
 	cmp.b	#_ConsoleMagic, Console.Magic(a3)
 	bne.s	@quit
 	move.w	d1, Console.BasePattern(a3)
-	
+
 @quit:
 	move.l	(sp)+, a3
 	rts
@@ -252,7 +251,7 @@ Console_SetWidth: __global
 	move.l	usp, a3
 	cmp.b	#_ConsoleMagic, Console.Magic(a3)
 	bne.s	@quit
-	addq.w	#4, a3
+	addq.w	#8, a3
 	move.w	d1, (a3)+
 	move.w	d1, (a3)+
 
@@ -312,7 +311,7 @@ Console_Write: __global
 	movem.w	d2-d4, (a3)			; save d2-d4 (ignore d6 as it won't get changes anyways ...)
 	swap	d5
 	movem.l	d5/d7, -(a3)		; save current and start-of-line positions
-	
+
 @quit:
 	movem.l	(sp)+, d1-d7/a3/a6
 	rts
@@ -440,7 +439,7 @@ Console_Write_Formatted: __global
 	moveq	#@buffer_size-2, d7			; d7 = number of characters before flush -1
 	jsr		FormatString(pc)
 	lea		@buffer_size(sp), sp		; free string buffer
-	
+
 	move.l	(sp)+, a4
 	rts
 

--- a/modules/core/Formatter_Hex.asm
+++ b/modules/core/Formatter_Hex.asm
@@ -43,7 +43,7 @@ FormatHex_Byte:
 	lsr.w	#4,d2
 	and.w	d3,d2						; get nibble
 	move.b	HexDigitToChar(pc,d2), (a0)+
-	
+
 	dbf		d7, FormatHex_Word_WriteLastNibble2
 	jsr		(a4)
 	bcc.s	FormatHex_Word_WriteLastNibble2
@@ -102,7 +102,7 @@ FormatHex_LongWord_Trim:
 FormatHex_LongWord_Trim_Swapped_NonZero:
 	bsr.s	FormatHex_Word_Trim
 	bcs.s	FormatHex_Return				; if buffer terminated, branch
-	bra		FormatHex_Word_Swapped			; should display a word without trimming now
+	bra.s		FormatHex_Word_Swapped			; should display a word without trimming now
 
 FormatHex_Word_Trim_Swapped:
 	swap	d1

--- a/modules/core/Formatter_Hex.asm
+++ b/modules/core/Formatter_Hex.asm
@@ -102,7 +102,7 @@ FormatHex_LongWord_Trim:
 FormatHex_LongWord_Trim_Swapped_NonZero:
 	bsr.s	FormatHex_Word_Trim
 	bcs.s	FormatHex_Return				; if buffer terminated, branch
-	bra.s		FormatHex_Word_Swapped			; should display a word without trimming now
+	bra		FormatHex_Word_Swapped			; should display a word without trimming now
 
 FormatHex_Word_Trim_Swapped:
 	swap	d1

--- a/modules/errorhandler-core/Debugger_Backtrace.asm
+++ b/modules/errorhandler-core/Debugger_Backtrace.asm
@@ -111,7 +111,7 @@ Debugger_Backtrace:	__global
 	@try_next_offset:
 		addq.l	#2, @stack_curr
 		cmpa.l	@stack_curr, @stack_top
-		bhs		@try_offset_loop
+		bhs.s		@try_offset_loop
 
 @done:
 	rts

--- a/modules/errorhandler-core/Debugger_Backtrace.asm
+++ b/modules/errorhandler-core/Debugger_Backtrace.asm
@@ -111,7 +111,7 @@ Debugger_Backtrace:	__global
 	@try_next_offset:
 		addq.l	#2, @stack_curr
 		cmpa.l	@stack_curr, @stack_top
-		bhs.s		@try_offset_loop
+		bhs		@try_offset_loop
 
 @done:
 	rts

--- a/modules/errorhandler-core/ErrorHandler.asm
+++ b/modules/errorhandler-core/ErrorHandler.asm
@@ -364,7 +364,7 @@ Error_DrawOffsetLocation__inj:	__global
 ;		a2		Registers buffer
 ; -----------------------------------------------------------------------------
 
-Error_DrawRegisters:     
+Error_DrawRegisters:
 	lea		-$10(sp), sp				; allocate string buffaro
 	moveq	#-1, d7						; size of the buffer for formatter functions (we assume buffer will never overflow)
 
@@ -478,12 +478,9 @@ ErrorHandler_SetupVDP:	__global
 	lea 	VDP_Ctrl, a5 			; a5 = VDP_Ctrl
 	lea 	-4(a5), a6				; a6 = VDP_Data
 
-	; Make sure there are no pending writes to VDP
-	tst.w	(a5)
-
-	; Make sure there are no DMA's occuring, otherwise wait
+	; Make sure there are no DMA's occurring, otherwise wait
 	@wait_dma:
-		move.w	(a5), ccr				; is DMA occuring?
+		move.w	(a5), ccr				; is DMA occurring? (also clears VDP write flag)
 		bvs.s	@wait_dma				; wait until it's finished
 
 	; Setup VDP registers for Error Handler screen
@@ -503,7 +500,7 @@ ErrorHandler_SetupVDP:	__global
 	move.l	d0, (a6)				; ''
 	move.l	#$40000010, (a5) 		; reset vertical scrolling
 	move.l	d0, (a6)				; ''
-	
+
 	; Fill screen with black
 	cram	$00, (a5)
 	move.w	d0, (a6)

--- a/modules/errorhandler-core/tests/FormatString.asm
+++ b/modules/errorhandler-core/tests/FormatString.asm
@@ -62,7 +62,7 @@ Main:
 		sub.l	a5, a0
 		move.w	a0, d3							; d3 = actual output size
 		cmp.w	d3, d4							; compare actual output size to the expected
-		bne.w		@SizeMismatch					; if they don't match, branch
+		bne.w	@SizeMismatch					; if they don't match, branch
 
 		subq.w	#1, d4
 		bmi.w	@NextTest
@@ -98,21 +98,21 @@ Main:
 
 	; -------------------------------------------------------------------------
 	@BufferOverflow:
-		bsr.w	@PrintFailureHeader
+		bsr		@PrintFailureHeader
 		Console.WriteLine '%<pal1>Error: Writting past the end of buffer'
-		bra.s @HaltTests
+		bra		@HaltTests
 
 	; -------------------------------------------------------------------------
 	@SizeMismatch:
-		bsr.w	@PrintFailureHeader
+		bsr		@PrintFailureHeader
 		Console.WriteLine '%<pal1>Error: Size mismatch (%<.b d3> != %<.b d4>)'
-		bra.w	@PrintFailureDiff
+		bra		@PrintFailureDiff
 
 	; -------------------------------------------------------------------------
 	@ByteMismatch:
-		bsr.w	@PrintFailureHeader
+		bsr		@PrintFailureHeader
 		Console.WriteLine '%<pal1>Error: Byte mismatch (%<.b -1(a1)> != %<.b -1(a5)>)'
-		bra.w	@PrintFailureDiff
+		bra		@PrintFailureDiff
 
 ; --------------------------------------------------------------
 ; Buffer flush function

--- a/modules/errorhandler-core/tests/FormatString.asm
+++ b/modules/errorhandler-core/tests/FormatString.asm
@@ -58,11 +58,11 @@ Main:
 
 		lea		(a5), a2						; a2 = Got string
 		lea		(a1), a3						; a3 = Expected string
-		
-		sub.l	a5, a0	
-		move.w	a0, d3							; d3 = actual output size  
+
+		sub.l	a5, a0
+		move.w	a0, d3							; d3 = actual output size
 		cmp.w	d3, d4							; compare actual output size to the expected
-		bne		@SizeMismatch					; if they don't match, branch
+		bne.w		@SizeMismatch					; if they don't match, branch
 
 		subq.w	#1, d4
 		bmi.w	@NextTest
@@ -77,42 +77,42 @@ Main:
 		adda.w	8(a6), a6						; a6 => Next test
 		tst.w	(a6)							; is test header valid?
 		bpl.w	@RunTest						; if yes, keep doing tests
-		
+
 	Console.WriteLine 'Number of completed tests: %<.b d1 dec>'
 	Console.WriteLine '%<pal1>ALL TESTS HAVE PASSED SUCCESSFULLY'
 	rts
 
-	; -------------------------------------------------------------------------		
+	; -------------------------------------------------------------------------
 	@PrintFailureHeader:
 		Console.WriteLine '%<pal2>Test #%<.b d1 dec> FAILED'
 		rts
 
-	; -------------------------------------------------------------------------		
+	; -------------------------------------------------------------------------
 	@PrintFailureDiff:
 		Console.WriteLine '%<pal0>Got:%<endl>%<pal2>"%<.l a2 str>"'
 		Console.WriteLine '%<pal0>Expected:%<endl>%<pal2>"%<.l a3 str>"'
-		
+
 	@HaltTests:
 		Console.WriteLine '%<pal1>TEST FAILURE, STOPPING'
 		rts
 
-	; -------------------------------------------------------------------------		
+	; -------------------------------------------------------------------------
 	@BufferOverflow:
-		bsr	@PrintFailureHeader
+		bsr.w	@PrintFailureHeader
 		Console.WriteLine '%<pal1>Error: Writting past the end of buffer'
-		bra @HaltTests
+		bra.s @HaltTests
 
-	; -------------------------------------------------------------------------		
+	; -------------------------------------------------------------------------
 	@SizeMismatch:
-		bsr	@PrintFailureHeader
+		bsr.w	@PrintFailureHeader
 		Console.WriteLine '%<pal1>Error: Size mismatch (%<.b d3> != %<.b d4>)'
-		bra	@PrintFailureDiff
+		bra.w	@PrintFailureDiff
 
-	; -------------------------------------------------------------------------		
+	; -------------------------------------------------------------------------
 	@ByteMismatch:
-		bsr	@PrintFailureHeader
+		bsr.w	@PrintFailureHeader
 		Console.WriteLine '%<pal1>Error: Byte mismatch (%<.b -1(a1)> != %<.b -1(a5)>)'
-		bra	@PrintFailureDiff
+		bra.w	@PrintFailureDiff
 
 ; --------------------------------------------------------------
 ; Buffer flush function
@@ -130,7 +130,7 @@ dcs	macro
 	@end\@:
 		dc.b	0				; also put a null-terminator, so MDShell may print it as C-string also ...
 	endm
-	
+
 addTest macro args,source_str,compare_str
 	@test_header\@:
 		dc.l	@source_string\@						; (a6) => Source string absolute pointer
@@ -148,7 +148,7 @@ addTest macro args,source_str,compare_str
 	@compare_string\@:
 		dcs <\compare_str>								; this string also includes "length" byte for correct computations
 		even
-		
+
 	@test_end\@:
 	endm
 
@@ -158,124 +158,124 @@ addTest macro args,source_str,compare_str
 	; NOTICE: Null-terminator is not included in the output string compared here.
 	;	While FormatString *does* add null-ternimator, returned buffer position
 	;	points *before* null-terminator, not *after* it (if no overflows occured).
-	
+
 	; TODOh: Replace numbers with literal constants ...
 
 	; #00: Simple test
 	addTest { <.l 0> }, &
 			<'Simple string',$00>, &
 			<'Simple string'>
-			
+
 	; #01: Buffer limit test #1 ($20 bytes)
 	addTest { <.l 0> }, &
 			<'This string might overflow the buffer!',$00>, &
 			<'This string might overflow the b'>
-			
-	; #02: Buffer limit test #2  
+
+	; #02: Buffer limit test #2
 	addTest { <.l 0> }, &
 			<'This string might overflow the b',$00>, &
 			<'This string might overflow the b'>
 
-	; #03: Buffer limit test #3               
+	; #03: Buffer limit test #3
 	addTest { <.l 0> }, &
 			<'This string might overflow the ',$00>, &
 			<'This string might overflow the '>
-			
-	; #04: Formatters test #1              
+
+	; #04: Formatters test #1
 	addTest { <.w 1234>, <.l $01234567>, <.l $89ABCDEF> }, &
 			<$91,$83,$83,$00>, &
 			<'12340123456789ABCDEF'>
 
-	; #05: Formatters test #2               
+	; #05: Formatters test #2
 	addTest { <.w 1234>, <.l $01234567>, <.l $89ABCDEF> }, &
 			<$91,' ',$83,' ',$83,$00>, &
 			<'1234 01234567 89ABCDEF'>
 
-	; #06: Formatters test #3            
+	; #06: Formatters test #3
 	addTest { <.w 1234>, <.l $01234567>, <.l $89ABCDEF> }, &
 			<'--',$91,' ',$83,' ',$83,'--',$00>, &
 			<'--1234 01234567 89ABCDEF--'>
 
-	; #07: Buffer limit + formatters test #1  
+	; #07: Buffer limit + formatters test #1
 	addTest { <.w 1234>, <.l $01234567>, <.l $89ABCDEF> }, &
 			<'--------',$91,' ',$83,' ',$83,'--',$00>, &
-			<'--------1234 01234567 89ABCDEF--'>   
-			
-	; #08: Buffer limit + formatters test #2         
+			<'--------1234 01234567 89ABCDEF--'>
+
+	; #08: Buffer limit + formatters test #2
 	addTest { <.w 1234>, <.l $01234567>, <.l $89ABCDEF> }, &
 			<'----------',$91,' ',$83,' ',$83,'--',$00>, &
-			<'----------1234 01234567 89ABCDEF'>   
+			<'----------1234 01234567 89ABCDEF'>
 
-	; #09: Buffer limit + formatters test #3   
+	; #09: Buffer limit + formatters test #3
 	addTest { <.w 1234>, <.l $01234567>, <.l $89ABCDEF> }, &
 			<'-----------',$91,' ',$83,' ',$83,'--',$00>, &
-			<'-----------1234 01234567 89ABCDE'>   
+			<'-----------1234 01234567 89ABCDE'>
 
-	; #10: Multiple formatters test     
+	; #10: Multiple formatters test
 	addTest { <.w 1234>, <.l $01234567>, <.l $89ABCDEF> }, &
 			<$99,' ',$A0,' ',$88,$00>, &
 			<'+1234 00100011 +67'>
-								
+
 	; #11: String decoding test #1
 	addTest { <.l @SampleString1> }, &
 			<$D0,$00>, &
 			<'<String insertion test>'>
-			
+
 	; #12: Buffer limit + String decoding test #1
 	addTest { <.l @SampleString1>, <.l @SampleString1> }, &
 			<$D0,$D0,$00>, &
 			<'<String insertion test><String i'>
-			
+
 	; #13: Buffer limit + String decoding test #2
 	addTest { <.l @SampleString2> }, &
 			<$D0,$00>, &
 			<'This string takes all the buffer'>
-			
+
 	; #14: Buffer limit + String decoding test #3
 	addTest { <.l @SampleString2>, <.l @SampleString2> }, &
 			<$D0,$D0,$00>, &
 			<'This string takes all the buffer'>
-			
+
 	; #15: Zero-length string decoding test #1
 	addTest { <.l @EmptyString> }, &
 			<'[',$D0,']',$00>, &
 			<'[]'>
-						
+
 	; #16: Zero-length string decoding test #2
 	addTest { <.l @EmptyString>, <.l @EmptyString>, <.l @EmptyString>, <.l @EmptyString> }, &
 			<$D0,$D0,'-',$D0,$D0,$00>, &
 			<'-'>
-			
+
 	; #17: Zero-length string decoding test #3
 	addTest { <.l @EmptyString>, <.l @EmptyString> }, &
 			<'[',$D0,$D0,']',$00>, &
 			<'[]'>
-	
+
 	; #18: Character decoding test #1
 	addTest { <.l @OneCharacterString> }, &
 			<$D0,$00>, &
 			<'a'>
-			
+
 	; #19: Character decoding test #2
 	addTest { <.l @OneCharacterString>, <.l @OneCharacterString> }, &
 			<$D0,$D0,$00>, &
 			<'aa'>
-			
+
 	; #20: Buffer limit + Character decoding test #1
 	addTest { <.l @OneCharacterString> }, &
 			<'This string takes all the buffer',$D0,$00>, &
 			<'This string takes all the buffer'>
-			
+
 	; #21: Buffer limit + Character decoding test #2
 	addTest { <.l @OneCharacterString> }, &
 			<'This string takes almost all ..',$D0,$00>, &
-			<'This string takes almost all ..a'>    
-			
+			<'This string takes almost all ..a'>
+
 	; #22: Buffer limit + Character decoding test #3
 	addTest { <.l @OneCharacterString>, <.l @OneCharacterString> }, &
 			<'This string takes almost all ..',$D0,$D0,$00>, &
 			<'This string takes almost all ..a'>
-			
+
 	; #23: Buffer limit + Character decoding test #4
 	addTest { <.l @OneCharacterString> }, &
 			<'This string takes almost all ..',$D0,'!',$00>, &
@@ -457,20 +457,20 @@ addTest macro args,source_str,compare_str
 			<'long_data_chunk+100010'>
 
 	dc.w	-1
-	 
+
 ; --------------------------------------------------------------
 @SampleString1:
 	dc.b	'<String insertion test>',0
-	
+
 @SampleString2:
 	dc.b	'This string takes all the buffer',0
-	
+
 @EmptyString:
 	dc.b	0
-	
+
 @OneCharacterString:
 	dc.b	'a',0
-	
+
 	even
 
 ; --------------------------------------------------------------

--- a/modules/errorhandler/tests/flow-test.asm
+++ b/modules/errorhandler/tests/flow-test.asm
@@ -70,7 +70,7 @@ Test_ExtendedFlags:
 	moveq	#24, d0				; X
 	moveq	#2, d1				; Y
 	jsr		MDDBG__Console_SetPosAsXY
-	move	#10, d1
+	moveq	#10, d1
 	jsr		MDDBG__Console_SetWidth
 	Console.Write "%<pal3>Paragraph fill test with %<pal2>direct API%<pal3> calls...%<pal0>"
 	movem.l	(sp)+, d0-d1

--- a/modules/errorhandler/tests/flow-test.asm
+++ b/modules/errorhandler/tests/flow-test.asm
@@ -64,12 +64,24 @@ Test_ExtendedFlags:
 	Console.Write "%<setx>%<1>%<setw>%<20>"
 #endif
 	Console.Write "Testing paragraph fill with 'setx' and 'setw' flags...%<pal0>"
+
+	; Using "Console_SetXY" and "Console_SetWidth" ...
+	movem.l	d0-d1, -(sp)
+	moveq	#24, d0				; X
+	moveq	#2, d1				; Y
+	jsr		MDDBG__Console_SetPosAsXY
+	move	#10, d1
+	jsr		MDDBG__Console_SetWidth
+	Console.Write "%<pal3>Paragraph fill test with %<pal2>direct API%<pal3> calls...%<pal0>"
+	movem.l	(sp)+, d0-d1
+
 #ifdef ASM68K
 	Console.Write "%<endl,setx,0,setw,40>"
 #else
 ##	; AS assembler implementation has limitations on formatting capabilities
 	Console.Write "%<endl>%<setx>%<0>%<setw>%<40>"
 #endif
+
 	jsr		CheckRegisterIntergity
 
 ; --------------------------------------------------------------
@@ -118,7 +130,7 @@ Test_ConsoleWriteExtended:
 ; --------------------------------------------------------------
 Test_MiscCommands:
 	; Using misc. commands related to Console enitity ...
-	Console.SetXY #3, #20
+	Console.SetXY #3, #22
 	Console.Write "Positioning test #1 ..."
 	Console.BreakLine
 	Console.Write "Positioning test #2 ..."


### PR DESCRIPTION
Figured I might as well contribute some improvements upstream. Aside from fixing the bug in Console_SetWidth and removing the redundant `tst.w (a0)` in ErrorHander_SetupVDP which I've previously discussed, I also found an addressing mode optimization in Console_Init (Console_FillTile is close enough that PC-relative with index can be used for its clever jump), as well as a few branch optimizations in the hex formatter, the backtrace debugger, and the FormatString test.
