### PR TITLE
Error Handler, MD Shell: Store strings separately in `asm68k-linkable` bundle

### DIFF
--- a/modules/errorhandler/Debugger.Macros.ASM68K.asm
+++ b/modules/errorhandler/Debugger.Macros.ASM68K.asm
@@ -92,7 +92,11 @@ Console &
 		if (__sp>0)
 			movem.l	a0-a2/d7, -(sp)
 			lea		4*4(sp), a2
+#ifndef LINKABLE-WITH-DATA-SECTION
 			lea		@str\@(pc), a1
+#else
+			lea		@str\@, a1
+#endif
 			jsr		MDDBG__Console_\0\_Formatted
 			movem.l	(sp)+, a0-a2/d7
 			if (__sp>8)
@@ -104,7 +108,11 @@ Console &
 		; ... Otherwise, use direct write as an optimization
 		else
 			move.l	a0, -(sp)
+#ifndef LINKABLE-WITH-DATA-SECTION
 			lea		@str\@(pc), a0
+#else
+			lea		@str\@, a0
+#endif
 			jsr		MDDBG__Console_\0
 			move.l	(sp)+, a0
 		endif
@@ -201,7 +209,11 @@ KDebug &
 		if (__sp>0)
 			movem.l	a0-a2/d7, -(sp)
 			lea		4*4(sp), a2
+#ifndef LINKABLE-WITH-DATA-SECTION
 			lea		@str\@(pc), a1
+#else
+			lea		@str\@, a1
+#endif
 			jsr		MDDBG__KDebug_\0\_Formatted
 			movem.l	(sp)+, a0-a2/d7
 			if (__sp>8)
@@ -213,7 +225,11 @@ KDebug &
 		; ... Otherwise, use direct write as an optimization
 		else
 			move.l	a0, -(sp)
+#ifndef LINKABLE-WITH-DATA-SECTION
 			lea		@str\@(pc), a0
+#else
+			lea		@str\@, a0
+#endif
 			jsr		MDDBG__KDebug_\0
 			move.l	(sp)+, a0
 		endif

--- a/modules/errorhandler/Debugger.Macros.ASM68K.asm
+++ b/modules/errorhandler/Debugger.Macros.ASM68K.asm
@@ -92,11 +92,7 @@ Console &
 		if (__sp>0)
 			movem.l	a0-a2/d7, -(sp)
 			lea		4*4(sp), a2
-#ifdef LINKABLE-WITH-DATA-SECTION
-			lea		MDDBG__ConsoleWriteData_\@, a1
-#else
 			lea		@str\@(pc), a1
-#endif
 			jsr		MDDBG__Console_\0\_Formatted
 			movem.l	(sp)+, a0-a2/d7
 			if (__sp>8)
@@ -108,11 +104,7 @@ Console &
 		; ... Otherwise, use direct write as an optimization
 		else
 			move.l	a0, -(sp)
-#ifdef LINKABLE-WITH-DATA-SECTION
-			lea		MDDBG__ConsoleWriteData_\@, a0
-#else
 			lea		@str\@(pc), a0
-#endif
 			jsr		MDDBG__Console_\0
 			move.l	(sp)+, a0
 		endif
@@ -128,7 +120,7 @@ Console &
 #else
 		; Store string data in a separate section
 		section dbgstrings
-	MDDBG__ConsoleWriteData_\@:
+	@str\@:
 		__FSTRING_GenerateDecodedString \1
 		even
 
@@ -209,11 +201,7 @@ KDebug &
 		if (__sp>0)
 			movem.l	a0-a2/d7, -(sp)
 			lea		4*4(sp), a2
-#ifdef LINKABLE-WITH-DATA-SECTION
-			lea		MDDBG__KDebugWriteData_\@, a1
-#else
 			lea		@str\@(pc), a1
-#endif
 			jsr		MDDBG__KDebug_\0\_Formatted
 			movem.l	(sp)+, a0-a2/d7
 			if (__sp>8)
@@ -225,11 +213,7 @@ KDebug &
 		; ... Otherwise, use direct write as an optimization
 		else
 			move.l	a0, -(sp)
-#ifdef LINKABLE-WITH-DATA-SECTION
-			lea		MDDBG__KDebugWriteData_\@, a0
-#else
 			lea		@str\@(pc), a0
-#endif
 			jsr		MDDBG__KDebug_\0
 			move.l	(sp)+, a0
 		endif
@@ -244,7 +228,7 @@ KDebug &
 #else
 		; Store string data in a separate section
 		section dbgstrings
-	MDDBG__KDebugWriteData_\@:
+	@str\@:
 		__FSTRING_GenerateDecodedString \1
 		even
 

--- a/modules/errorhandler/Debugger.Macros.ASM68K.asm
+++ b/modules/errorhandler/Debugger.Macros.ASM68K.asm
@@ -92,7 +92,11 @@ Console &
 		if (__sp>0)
 			movem.l	a0-a2/d7, -(sp)
 			lea		4*4(sp), a2
+#ifdef LINKABLE-WITH-DATA-SECTION
+			lea		MDDBG__ConsoleWriteData_\@, a1
+#else
 			lea		@str\@(pc), a1
+#endif
 			jsr		MDDBG__Console_\0\_Formatted
 			movem.l	(sp)+, a0-a2/d7
 			if (__sp>8)
@@ -104,17 +108,33 @@ Console &
 		; ... Otherwise, use direct write as an optimization
 		else
 			move.l	a0, -(sp)
+#ifdef LINKABLE-WITH-DATA-SECTION
+			lea		MDDBG__ConsoleWriteData_\@, a0
+#else
 			lea		@str\@(pc), a0
+#endif
 			jsr		MDDBG__Console_\0
 			move.l	(sp)+, a0
 		endif
 
 		move.w	(sp)+, sr
+
+#ifndef LINKABLE-WITH-DATA-SECTION
 		bra.w	@instr_end\@
 	@str\@:
 		__FSTRING_GenerateDecodedString \1
 		even
 	@instr_end\@:
+#else
+		; Store string data in a separate section
+		section dbgstrings
+	MDDBG__ConsoleWriteData_\@:
+		__FSTRING_GenerateDecodedString \1
+		even
+
+		; Back to previous section (it should be 'rom' for this trick to work)
+		section	rom
+#endif
 
 #ifndef MD-SHELL
 	elseif strcmp("\0","run")|strcmp("\0","Run")
@@ -189,7 +209,11 @@ KDebug &
 		if (__sp>0)
 			movem.l	a0-a2/d7, -(sp)
 			lea		4*4(sp), a2
+#ifdef LINKABLE-WITH-DATA-SECTION
+			lea		MDDBG__KDebugWriteData_\@, a1
+#else
 			lea		@str\@(pc), a1
+#endif
 			jsr		MDDBG__KDebug_\0\_Formatted
 			movem.l	(sp)+, a0-a2/d7
 			if (__sp>8)
@@ -201,17 +225,32 @@ KDebug &
 		; ... Otherwise, use direct write as an optimization
 		else
 			move.l	a0, -(sp)
+#ifdef LINKABLE-WITH-DATA-SECTION
+			lea		MDDBG__KDebugWriteData_\@, a0
+#else
 			lea		@str\@(pc), a0
+#endif
 			jsr		MDDBG__KDebug_\0
 			move.l	(sp)+, a0
 		endif
 
 		move.w	(sp)+, sr
+#ifndef LINKABLE-WITH-DATA-SECTION
 		bra.w	@instr_end\@
 	@str\@:
 		__FSTRING_GenerateDecodedString \1
 		even
 	@instr_end\@:
+#else
+		; Store string data in a separate section
+		section dbgstrings
+	MDDBG__KDebugWriteData_\@:
+		__FSTRING_GenerateDecodedString \1
+		even
+
+		; Back to previous section (it should be 'rom' for this trick to work)
+		section	rom
+#endif
 
 	elseif strcmp("\0","breakline")|strcmp("\0","BreakLine")
 		move.w	sr, -(sp)

--- a/modules/errorhandler/Makefile
+++ b/modules/errorhandler/Makefile
@@ -50,7 +50,7 @@ $(BUILD_DIR)/asm68k-extsym/Debugger.asm $(BUILD_DIR)/asm68k-extsym/ErrorHandler.
 
 $(BUILD_DIR)/asm68k-linkable/Debugger.asm $(BUILD_DIR)/asm68k-linkable/Debugger.obj &: $(SRC_FILES) $(CORE_BUILD_DIR)/ErrorHandler.obj $(BUILD_DIR)/ErrorHandler.Refs.asm | $(BUILD_DIR) $(CBUNDLE)
 	mkdir -p $(BUILD_DIR)/asm68k-linkable
-	$(CBUNDLE) $(SRC_DIR)/Debugger.asm -def BUNDLE-ASM68K -def LINKABLE -out $(BUILD_DIR)/asm68k-linkable/Debugger.asm
+	$(CBUNDLE) $(SRC_DIR)/Debugger.asm -def BUNDLE-ASM68K -def LINKABLE -def LINKABLE-WITH-DATA-SECTION -out $(BUILD_DIR)/asm68k-linkable/Debugger.asm
 	cp $(CORE_BUILD_DIR)/ErrorHandler.obj $(BUILD_DIR)/asm68k-linkable/Debugger.obj
 
 $(BUILD_DIR)/as/Debugger.asm $(BUILD_DIR)/as/ErrorHandler.asm &: $(SRC_FILES) $(CORE_BUILD_DIR)/ErrorHandler.Blob.asm $(CORE_BUILD_DIR)/ErrorHandler.Globals.asm | $(BUILD_DIR) $(CBUNDLE)

--- a/modules/mdshell/Makefile
+++ b/modules/mdshell/Makefile
@@ -38,7 +38,7 @@ $(BUILD_DIR)/asm68k/MDShell.asm:	$(SRC_FILES) $(EH_SRC_FILES) $(CORE_BUILD_DIR)/
 
 $(BUILD_DIR)/asm68k-linkable/MDShell.asm $(BUILD_DIR)/asm68k-linkable/MDShell.obj &:	$(SRC_FILES) $(EH_SRC_FILES) $(CORE_BUILD_DIR)/MDShell.Refs.asm $(CORE_BUILD_DIR)/MDShell.obj | $(BUILD_DIR) $(CBUNDLE)
 	mkdir -p $(BUILD_DIR)/asm68k-linkable
-	$(CBUNDLE) $(SRC_DIR)/MDShell.asm -def MD-SHELL -def BUNDLE-ASM68K -def LINKABLE -out $(BUILD_DIR)/asm68k-linkable/MDShell.asm
+	$(CBUNDLE) $(SRC_DIR)/MDShell.asm -def MD-SHELL -def BUNDLE-ASM68K -def LINKABLE -def LINKABLE-WITH-DATA-SECTION -out $(BUILD_DIR)/asm68k-linkable/MDShell.asm
 	cp $(CORE_BUILD_DIR)/MDShell.obj $(BUILD_DIR)/asm68k-linkable/MDShell.obj
 
 $(BUILD_DIR)/as/MDShell.asm:	$(SRC_FILES) $(EH_SRC_FILES) $(CORE_BUILD_DIR)/MDShell.Globals.asm $(CORE_BUILD_DIR)/MDShell.Blob.asm | $(BUILD_DIR) $(CBUNDLE)

--- a/modules/mdshell/tests/linkable.asm
+++ b/modules/mdshell/tests/linkable.asm
@@ -19,6 +19,19 @@
 ; --------------------------------------------------------------
 
 Main:
+	; In linkable builds, `.Write[Line]` functions store strings
+	; in `dbgstrings` section and they switch back and forth
+	; between `rom` and `dbgstrings` in macro invocation.
+	; In this stress test we ensure
+	; both ASM68K and PSYLINK are able to handle many section
+	; switches without issues.
+	KDebug.WriteLine "Linkable KDebug stress test..."
+	@counter: = 0
+	rept 1024
+		@counter: = @counter + 1
+		KDebug.WriteLine "Wrote stored string \#@counter/1024."
+	endr
+
 	KDebug.WriteLine "Entering Main..."
 
 	moveq	#$5F, d7


### PR DESCRIPTION
Store string data in a dedicated `dbgstrings` section. This reduces the size of `Console.Write[Line]` and `KDebug.Write[Line]` by a lot and saves on `bra.w` instruction to jump over otherwise in-place strings.

Unfortunately, this optimization is only possible in `asm68k-linkable` bundle, where linker can easily merge and re-organize sections in order of their appearance (`rom` first, `dbgstrings` second).