### PR TITLE
Error Handler, MD Shell: Console scrolling

### DIFF
--- a/modules/core/Console.defs.asm
+++ b/modules/core/Console.defs.asm
@@ -15,16 +15,18 @@ _CONSOLE_DEFS:	equ	1
 ; ---------------------------------------------------------------
 
 			rsreset
-Console_RAM				equ		__rs
-Console.ScreenPosReq	rs.l	1				;		current on-screen position request for VDP
+Console_RAM:			equ		__rs
+Console.ScreenPosReq:	rs.l	1				;		current on-screen position request for VDP
 Console.ScreenRowReq:	rs.l	1				;		start of row position request for VDP
-Console.CharsPerLine	rs.w	1				; d2	number of characters per line
-Console.CharsRemaining	rs.w	1				; d3	remaining number of characters
-Console.BasePattern		rs.w	1				; d4	base pattern
-Console.ScreenRowSz		rs.w	1				; d6	row size within screen position
-Console.Magic			rs.b	1				;		should contain a magic number to ensure this is valid console memory area
-						rs.b	1				;		<Reserved>
-Console_RAM.size		equ		__rs-Console_RAM
+Console.CharsPerLine:	rs.w	1				; d2	number of characters per line
+Console.CharsRemaining:	rs.w	1				; d3	remaining number of characters
+Console.BasePattern:	rs.w	1				; d4	base pattern
+Console.ScreenRowSz:	rs.w	1				; d6	row size within screen position
+Console.YScrollTile:	rs.b	1				;		start tile for Y-scrolling (e.g. $02 = scroll past first two rows)
+Console.XScrollTile:	rs.b	1				;		start tile for X-scrolling (e.g. $02 = scroll past first two cols)
+Console.Magic:			equ		__rs			;		should contain a magic number to ensure this is valid console memory area (uses MSB of the next longword)
+Console.VRAMConfigPtr:	rs.l	1				;		pointer to Console's initial VRAM config (part of Console config containing VRAM and VSRAM offsets for the screen)
+Console_RAM.size:		equ		__rs-Console_RAM
 
 ; ---------------------------------------------------------------
 ; Constants

--- a/modules/core/Format_String.defs.asm
+++ b/modules/core/Format_String.defs.asm
@@ -119,9 +119,9 @@ __FSTRING_GenerateDecodedString &
 			
 			; Validate format setting ("param")
 			if strlen("\__param")<1
-				__param: substr ,,"hex"			; if param is ommited, set it to "hex"
+				__param: substr ,,"_hex"			; if param is ommited, set it to "hex"
 			elseif strcmp("\__param","signed")
-				__param: substr ,,"hex+signed"	; if param is "signed", correct it to "hex+signed"
+				__param: substr ,,"_hex+signed"		; if param is "signed", correct it to "hex+signed"
 			endif
 
 			if (\__param < $80)

--- a/modules/errorhandler-core/ErrorHandler.asm
+++ b/modules/errorhandler-core/ErrorHandler.asm
@@ -24,6 +24,8 @@
 
 VRAM_Font:			equ 	(('!'-1)*$20)
 VRAM_ErrorScreen:	equ		$8000
+VRAM_ErrorHScroll:	equ		$FC00
+VSRAM_ErrorVScroll:	equ		$00
 
 _white:				equ 	0
 _yellow: 			equ 	1<<13
@@ -528,7 +530,7 @@ ErrorHandler_VDPConfig:	__global
 	dc.w	$8700							; $07, set backdrop color
 	dc.w	$8B00							; $0B, set VScroll=full, HScroll=full
 	dc.w	$8C81							; $0C, use 320 pixels horizontal resolution
-	dc.w	$8D00							; $0D, set HScroll table offset to $0000
+	dc.w	$8D3F							; $0D, set HScroll table offset to $FC00
 	dc.w	$8F02							; $0F, set auto-increment to $02
 	dc.w	$9011							; $10, use 512x512 plane resolution
 	dc.w	$9100							; $11, reset Window X-position
@@ -595,9 +597,9 @@ ErrorHandler_ConsoleConfig:
 
 ErrorHandler_ConsoleConfig_Initial:	__global
 	dcvram	VRAM_ErrorScreen			; screen start address / plane nametable pointer
-	; fallthrough
+	dcvram	VRAM_ErrorHScroll			; HSRAM address
+	dc.w	VSRAM_ErrorVScroll			; VSRAM address
 
-ErrorHandler_ConsoleConfig_Shared:	__global
 	dc.w	40							; number of characters per line
 	dc.w	40							; number of characters on the first line (meant to be the same as the above)
 	dc.w	0							; base font pattern (tile id for ASCII $00 + palette flags)

--- a/modules/errorhandler-core/Extensions.asm
+++ b/modules/errorhandler-core/Extensions.asm
@@ -41,28 +41,6 @@ ErrorHandler_ConsoleOnly:	__global
 
 ; =============================================================================
 ; -----------------------------------------------------------------------------
-; Clears currently used console
-; -----------------------------------------------------------------------------
-
-ErrorHandler_ClearConsole:	__global
-	move.l	a3, -(sp)
-	move.l	usp, a3
-	cmp.b	#_ConsoleMagic, Console.Magic(a3)
-	bne.s	@quit
-
-	movem.l	d0-d1/d5/a1/a5-a6, -(sp)
-	lea		VDP_Ctrl, a5				; a5 = VDP_Ctrl
-	lea		-4(a5), a6					; a6 = VDP_Data
-	lea		ErrorHandler_ConsoleConfig_Initial(pc), a1
-	jsr		Console_Reset(pc)
-	movem.l	(sp)+, d0-d1/d5/a1/a5-a6
-@quit:
-	move.l	(sp)+, a3
-	rts
-
-
-; =============================================================================
-; -----------------------------------------------------------------------------
 ; Pause console program executions until A/B/C are pressed
 ; -----------------------------------------------------------------------------
 
@@ -73,9 +51,9 @@ ErrorHandler_PauseConsole:	__global
 	bne.s	@quit
 
 	move.w	#0, -(sp)					; allocate joypad memory
-	bsr.s	Joypad_Wait_ABCStart		; extra call to initialize joypad bitfield and avoid misdetecting pressed buttons
+	bsr.s	ReadJoypad_And_CheckABCStart		; extra call to initialize joypad bitfield and avoid misdetecting pressed buttons
 @loop:
-	bsr.s	Joypad_Wait_ABCStart		; is A/B/C pressed?
+	bsr.s	ReadJoypad_And_CheckABCStart		; is A/B/C pressed?
 	beq.s	@loop						; if not, branch
 
 	addq.w	#2, sp
@@ -85,108 +63,18 @@ ErrorHandler_PauseConsole:	__global
 	rts
 
 
-; -----------------------------------------------------------------------------
-; Pause console program executions until A/B/C or Start are pressed
-; -----------------------------------------------------------------------------
-; INPUT:
-;		4(sp)	Pointer to a word that stores pressed/held buttons
-;
-; OUTPUT:
-;		d0	.b	Pressed A/B/C/Start state; Format: %SACB0000
-;
-; USES:
-;		d0-d1 / a0-a1
-; -----------------------------------------------------------------------------
-
-Joypad_Wait_ABCStart:
-	bsr.s	VSync
-	lea		4(sp), a0					; a0 = Joypad memory
-	lea		$A10003, a1					; a1 = Joypad 1 Port
-	bsr.s	ReadJoypad
-	moveq	#$FFFFFFF0, d0
-	and.b	5(sp), d0					; Start/A/B/C pressed?
-	rts									; return Z=0 if pressed
-
-
 ; =============================================================================
 ; -----------------------------------------------------------------------------
-; A simple controller that allows switching between Debuggers
+; Initialize joypads
 ; -----------------------------------------------------------------------------
 
-ErrorHandler_PagesController:	__global
-	movem.l	d0-a6, -(sp)				; back up all the registers ...
-	move.w	#0, -(sp)					; allocate joypad memory
-	bsr.s	Joypad_Wait_ABCStart		; extra call to initialize joypad bitfield and avoid misdetecting pressed buttons
-
-@MainLoop:
-		lea		VDP_Ctrl, a5				; a5 = VDP_Ctrl
-		lea		-4(a5), a6					; a6 = VDP_Data
-
-		bsr.s	Joypad_Wait_ABCStart		; Start/A/B/C pressed?
-		beq.s	@MainLoop					; if not, branch
-		bmi.s	@ShowMainErrorScreen		; if Start pressed, branch
-
-		; Detect debugger to run depending on currently pressed button (A/B/C)
-		lea		ErrorHandler_ExtraDebuggerList-4-4(pc), a0		; another "-4" to skip always-reset Start button
-
-	@ChkButton:
-			addq.l	#4, a0						; next debugger
-			add.b	d0, d0
-			bcc.s	@ChkButton
-
-		move.l	(a0), d0					; d0 = debugger address
-		ble.s	@ShowMainErrorScreen		; if address is zero or negative, branch
-		movea.l	d0, a0
-
-		; Initialize console for the debugger
-		lea		-Console_RAM.size(sp), sp	; allocate memory for console
-		lea		ErrorHandler_ConsoleConfig_Shared(pc), a1
-		lea		(sp), a3					; a3 = Console RAM
-		vram	VRAM_DebuggerPage, d5		; d5 = Screen start address
-		jsr		Console_InitShared(pc)
-
-		; Display debugger's own console
-		move.l	#(($8200+VRAM_DebuggerPage/$400)<<16)|($8400+VRAM_DebuggerPage/$2000), (a5)
-		move.l	d5, (a5)					; restore last VDP write address
-
-		; Execute the debugger
-		pea		@DestroyDebugger(pc)
-		pea		(a0)						; use debbuger's context upon return
-		movem.l	Console_RAM.size+2+4(sp), d0-a6	; switch to original registers ...
-		rts									; switch to debugger's context ...
-
-; -----------------------------------------------------------------------------
-@DestroyDebugger:
-		lea		Console_RAM.size(sp), sp	; deallocate console memory
-		bra.s	@MainLoop
-
-; -----------------------------------------------------------------------------
-@ShowMainErrorScreen:
-		; WARNING! Make sure a5 is "VDP_Ctrl"!
-		move.l	ErrorHandler_VDPConfig_Nametables(pc), (a5)
-		bra.s	@MainLoop
-
-
-; =============================================================================
-; -----------------------------------------------------------------------------
-; Performs VSync
-; -----------------------------------------------------------------------------
-
-VSync:	__global
-	lea		VDP_Ctrl, a0
-
-@loop0:
-		move.w	(a0), ccr
-		bmi.s	@loop0
-
-@loop1:
-		move.w	(a0), ccr
-		bpl.s	@loop1
-
+InitJoypad:
+	moveq	#$40,d0
+	move.b	d0, ($A10009).l	; init port 1 (joypad 1)
+	move.b	d0, ($A1000B).l	; init port 2 (joypad 2)
+	move.b	d0, ($A1000D).l	; init port 3 (extra)
 	rts
 
-
-; =============================================================================
 ; -----------------------------------------------------------------------------
 ; Reads input from joypad
 ; -----------------------------------------------------------------------------
@@ -210,6 +98,171 @@ ReadJoypad:
 	and.b	d0, d1
 	move.b	d1, (a0)+			; put pressed controller input
 	rts
+
+; -----------------------------------------------------------------------------
+; Pause console program executions until A/B/C or Start are pressed
+; -----------------------------------------------------------------------------
+; INPUT:
+;		4(sp)	Pointer to a word that stores pressed/held buttons
+;
+; OUTPUT:
+;		d0	.b	Pressed A/B/C/Start state; Format: %SACB0000
+;
+; USES:
+;		d0-d1 / a0-a1
+; -----------------------------------------------------------------------------
+
+ReadJoypad_And_CheckABCStart:
+	bsr		VSync
+	lea		4(sp), a0					; a0 = Joypad memory
+	lea		$A10003, a1					; a1 = Joypad 1 Port
+	bsr.s	ReadJoypad
+	moveq	#$FFFFFFF0, d0
+	and.b	5(sp), d0					; Start/A/B/C pressed?
+	rts									; return Z=0 if pressed
+
+
+; =============================================================================
+; -----------------------------------------------------------------------------
+; A simple controller that allows switching between Debuggers
+; -----------------------------------------------------------------------------
+
+ErrorHandler_PagesController:	__global
+	movem.l	d0-a6, -(sp)				; back up all the registers ...
+	bsr.s	InitJoypad					; initialize joypads (in case they weren't initilialized before)
+
+	lea		-Console_RAM.size(sp), sp	; allocate memory for console
+	move.l	usp, a0
+	move.l	a0, -(sp)					; save original debugger's console state
+	move.w	#0, -(sp)					; allocate joypad memory
+
+	bsr.s	ReadJoypad_And_CheckABCStart; extra call to initialize joypad bitfield and avoid misdetecting pressed buttons
+
+@MainLoop:
+		lea		VDP_Ctrl, a5				; a5 = VDP_Ctrl
+		lea		-4(a5), a6					; a6 = VDP_Data
+
+		bsr.s	ReadJoypad_And_CheckABCStart; Start/A/B/C pressed?
+		beq.s	@HandleConsoleScrolling		; if not, branch
+		bmi.s	@ShowMainErrorScreen		; if Start pressed, branch
+
+		; Detect debugger to run depending on currently pressed button (A/B/C)
+		lea		ErrorHandler_ExtraDebuggerList-4-4(pc), a0		; another "-4" to skip always-reset Start button
+
+	@ChkButton:
+			addq.l	#4, a0						; next debugger
+			add.b	d0, d0
+			bcc.s	@ChkButton
+
+		move.l	(a0), d0					; d0 = debugger address
+		ble.s	@ShowMainErrorScreen		; if address is zero or negative, branch
+		movea.l	d0, a0
+
+		; Initialize console for the debugger
+		lea		@ConsoleConfig_SecondaryDebugger(pc), a1
+		lea		2+4+Console_RAM.size(sp), a3	; a3 = Console RAM
+		jsr		Console_InitShared(pc)
+
+		; Display debugger's own console
+		move.l	#(($8200+VRAM_DebuggerPage/$400)<<16)|($8400+VRAM_DebuggerPage/$2000), (a5)
+		move.l	d5, (a5)					; restore last VDP write address
+
+		; Execute the debugger
+		pea		@MainLoop(pc)
+		pea		(a0)								; use debbuger's context upon return
+		movem.l	2+4+Console_RAM.size+4(sp), d0-a6	; switch to original registers ...
+		rts											; switch to debugger's context ...
+
+	; -----------------------------------------------------------------------------
+	@HandleConsoleScrolling:
+			move.b	1(sp), d0						; d0 = pressed buttons, extacted by `ReadJoypad_And_CheckABCStart`
+			bsr.s	HandleConsoleScrolling
+			bra		@MainLoop
+
+	; -----------------------------------------------------------------------------
+	@ShowMainErrorScreen:
+			move.l	ErrorHandler_VDPConfig_Nametables(pc), (a5)
+			move.l	2(sp), a0
+			move.l	a0, usp									; restore console state
+			moveq	#0, d0
+			moveq	#0, d1
+			bsr		Console_SetXYTileScrollPosition			; reset console scrolling
+			bra		@MainLoop
+
+; -----------------------------------------------------------------------------
+@ConsoleConfig_SecondaryDebugger:
+	dcvram	VRAM_DebuggerPage			; screen start address / plane nametable pointer
+	dcvram	VRAM_ErrorHScroll			; HSRAM address
+	dc.w	VSRAM_ErrorVScroll			; VSRAM address
+
+	dc.w	40							; number of characters per line
+	dc.w	40							; number of characters on the first line (meant to be the same as the above)
+	dc.w	0							; base font pattern (tile id for ASCII $00 + palette flags)
+	dc.w	$80							; size of screen row (in bytes)
+
+	dc.w	$2000/$20-1					; size of screen (in tiles - 1)
+
+; -----------------------------------------------------------------------------
+;
+; -----------------------------------------------------------------------------
+; INPUT:
+;		d0	.b		Pressed buttons bitfield
+;
+; USES:
+;		d0-d1
+; -----------------------------------------------------------------------------
+
+HandleConsoleScrolling:
+	lsl.b	#4, d0
+	bmi.s	@ScrollRight
+	add.b	d0, d0
+	bmi.s	@ScrollLeft
+	add.b	d0, d0
+	bmi.s	@ScrollDown
+	add.b	d0, d0
+	bpl.s	@Quit
+
+@ScrollUp:
+	bsr		Console_GetXYTileScrollPosition
+	subq.b	#1, d1
+	bra		Console_SetXYTileScrollPosition
+
+@ScrollDown:
+	bsr		Console_GetXYTileScrollPosition
+	addq.b	#1, d1
+	bra		Console_SetXYTileScrollPosition
+
+@ScrollLeft:
+	bsr		Console_GetXYTileScrollPosition
+	subq.b	#1, d0
+	bra		Console_SetXYTileScrollPosition
+
+@ScrollRight:
+	bsr		Console_GetXYTileScrollPosition
+	addq.b	#1, d0
+	bra		Console_SetXYTileScrollPosition
+
+@Quit:
+	rts
+
+; =============================================================================
+; -----------------------------------------------------------------------------
+; Performs VSync
+; -----------------------------------------------------------------------------
+
+VSync:	__global
+	lea		VDP_Ctrl, a0
+
+@loop0:
+		move.w	(a0), ccr
+		bmi.s	@loop0
+
+@loop1:
+		move.w	(a0), ccr
+		bpl.s	@loop1
+
+	rts
+
 
 ; -----------------------------------------------------------------------------
 ; Extra debugger to button mappings

--- a/modules/errorhandler/Debugger.Macros.AS.asm
+++ b/modules/errorhandler/Debugger.Macros.AS.asm
@@ -217,7 +217,7 @@ Console	macro	argument1, argument2
 #endif
 	case "clear"
 		move.w	sr, -(sp)
-		jsr		MDDBG__ErrorHandler_ClearConsole
+		jsr		MDDBG__Console_Clear
 		move.w	(sp)+, sr
 
 	case "pause"

--- a/modules/errorhandler/Debugger.Macros.ASM68K.asm
+++ b/modules/errorhandler/Debugger.Macros.ASM68K.asm
@@ -211,7 +211,7 @@ Console &
 #endif
 	elseif strcmp("\0","clear")|strcmp("\0","Clear")
 		move.w	sr, -(sp)
-		jsr		MDDBG__ErrorHandler_ClearConsole
+		jsr		MDDBG__Console_Clear
 		move.w	(sp)+, sr
 
 	elseif strcmp("\0","pause")|strcmp("\0","Pause")


### PR DESCRIPTION
This PR implements basic console scrolling when pressing D-Pad. This should be extremely useful if screen content doesn't fit vertically (e.g. backtrace is too long).

## TODO

- Add `Console.SetXYScroll` macro;
- Add `Console.VSync` macro (maybe squeeze it in here?);
- Code size optimizations if feasible;
- Scrolling in MD Shell and `Console.Run`;
